### PR TITLE
Make tooltip compute it's own size

### DIFF
--- a/src/Tooltip/driver.js
+++ b/src/Tooltip/driver.js
@@ -13,11 +13,11 @@ export default class TooltipDriver extends SimpleComponentDriver
 
     getContent()
     {
-        return this.wrapper.find( `.${this.cssMap.content}` ).children();
+        return this.wrapper.find( `.${this.cssMap.content}` ).first().children();
     }
 
     getMessage()
     {
-        return this.wrapper.find( `.${this.cssMap.message}` ).children();
+        return this.wrapper.find( `.${this.cssMap.message}` ).first().children();
     }
 }

--- a/src/Tooltip/tooltip.css
+++ b/src/Tooltip/tooltip.css
@@ -27,6 +27,7 @@
     position:           absolute;
 
     width:              auto;
+    max-width:          400px;
 
     margin-bottom:      0;
 
@@ -287,4 +288,15 @@
     {
         background-color:         var( --PC-ORANGE );
     }
+}
+
+.ghost
+{
+    display:     block;
+    white-space: pre-wrap;
+    word-wrap:   break-word;
+    visibility:  hidden;
+    position:    fixed;
+    width:       100vw;
+    left:         -9999px;
 }


### PR DESCRIPTION
This PR adds support to the Tooltip component to compute it's own size when having non-text content.

Previously, when adding a tooltip to a small component (i.e. Icon), the width of the tooltip when having HTML content, was equal to the widest element inside. Now, it's maximum 400px, based on how elements are wrapped inside.

This functionality was accomplished by having a ghost container rendered outside of the viewport and measuring it. It's width is now applied to the tooltip :)