### PR TITLE
Issue 464 fix on scroll interface

### DIFF
--- a/src/ScrollBox/index.jsx
+++ b/src/ScrollBox/index.jsx
@@ -1,11 +1,12 @@
-import React, { Component } from 'react';
-import PropTypes            from 'prop-types';
-import isEqual              from 'lodash.isequal';
+import React, { Component }    from 'react';
+import PropTypes               from 'prop-types';
+import isEqual                 from 'lodash.isequal';
 
-import { buildClassName }   from '../utils';
-import styles               from './scrollBox.css';
-import IconButton           from '../IconButton';
-import ScrollBar            from '../ScrollBar';
+import { createScrollHandler } from './utils';
+import { buildClassName }      from '../utils';
+import styles                  from './scrollBox.css';
+import IconButton              from '../IconButton';
+import ScrollBar               from '../ScrollBar';
 
 
 export default class ScrollBox extends Component
@@ -219,10 +220,11 @@ export default class ScrollBox extends Component
     {
         this.forceUpdate();
 
-        const { onScroll } = this.props;
-        if ( onScroll )
+        const { props } = this;
+
+        if ( props.onScroll )
         {
-            onScroll( e );
+            createScrollHandler( props.onScroll, props.scroll )( e );
         }
     }
 

--- a/src/ScrollBox/tests.jsx
+++ b/src/ScrollBox/tests.jsx
@@ -1,12 +1,14 @@
 /* global test jest */
-/* eslint no-console: 0*/
+/* eslint-disable no-magic-numbers, no-multi-str */
 
-import React                 from 'react';
-import { mount, shallow }    from 'enzyme';
+import React              from 'react';
+import { mount, shallow } from 'enzyme';
 
-import ScrollBar             from '../ScrollBar';
+import ScrollBar          from '../ScrollBar';
+import * as utils         from './utils';
 
-import ScrollBox             from './index';
+import ScrollBox          from './index';
+
 
 describe( 'ScrollBox', () =>
 {
@@ -56,6 +58,35 @@ describe( 'ScrollBox', () =>
 
         expect( wrapper.find( ScrollBar ).last().prop( 'thumbSize' ) )
             .toBe( '50%' );
+    } );
+
+    describe( 'handleScroll', () =>
+    {
+        let scrollHandler;
+
+        test( 'forces component to update', () =>
+        {
+            jest.spyOn( instance, 'forceUpdate' );
+            instance.handleScroll();
+            expect( instance.forceUpdate ).toBeCalledTimes( 1 );
+        } );
+
+        test( 'calls createScrollHandler if onScroll prop is defined', () =>
+        {
+            scrollHandler = jest.fn();
+            jest.spyOn( utils, 'createScrollHandler' )
+                .mockImplementation( () => scrollHandler );
+
+            wrapper.setProps( { onScroll: jest.fn() } );
+            instance.handleScroll();
+            expect( utils.createScrollHandler ).toBeCalledTimes( 1 );
+        } );
+
+        test( '...then calls the resulting function', () =>
+        {
+            expect( scrollHandler ).toBeCalledTimes( 1 );
+            utils.createScrollHandler.mockRestore();
+        } );
     } );
 } );
 


### PR DESCRIPTION
For #464:
- Restores the previous behavior of the ScrollBox where the `onScroll` callback receives the updated scroll position as a percentage