### PR TITLE
Converted React.PureComponent’s to functions #425

### DIFF
--- a/src/PasswordInput/index.jsx
+++ b/src/PasswordInput/index.jsx
@@ -1,168 +1,192 @@
-import React                                    from 'react';
-import PropTypes                                from 'prop-types';
+import React                          from 'react';
+import PropTypes                      from 'prop-types';
 
-import { generateId, buildClassName }           from '../utils';
-import { TextInputWithIcon }                    from '../index';
+import { generateId, buildClassName } from '../utils';
+import { TextInputWithIcon }          from '../index';
+import styles                         from './passwordInput.css';
 
 
-export default class PasswordInput extends React.PureComponent
+const PasswordInput = ( {
+    className,
+    cssMap,
+    id = generateId( 'PasswordInput' ),
+    passwordIsVisible,
+    ...props
+} ) => (
+    <TextInputWithIcon
+        { ...props }
+        className = { buildClassName( className, cssMap ) }
+        id        = { id }
+        inputType = { passwordIsVisible ? 'text' : 'password' }
+        iconType  = { passwordIsVisible ? 'hide' : 'show' } />
+);
+
+
+PasswordInput.propTypes =
 {
-    static propTypes =
-    {
-        /**
-         *  Label text string or JSX node
-         */
-        label                 : PropTypes.node,
-        /**
-         *  alternates input and icon types accordingly.
-         */
-        passwordIsVisible     : PropTypes.bool,
-        /**
-         *  Label position
-         */
-        labelPosition         : PropTypes.oneOf( [ 'top', 'left', 'right' ] ),
-        /**
-         *  Placeholder text
-         */
-        placeholder           : PropTypes.string,
-        /**
-         *  Display as disabled/read-only
-         */
-        isDisabled            : PropTypes.bool,
-        /**
-         *  Display as read-only
-         */
-        isReadOnly            : PropTypes.bool,
-        /**
-         *  Display as error/invalid
-         */
-        hasError              : PropTypes.bool,
-        /**
-         *  Tooltip message text (string or JSX)
-         */
-        errorMessage          : PropTypes.node,
-        /**
-         *  Tooltip is displayed
-         */
-        errorMessageIsVisible : PropTypes.bool,
-        /**
-         *  Error message position relative to the icon
-         */
-        errorMessagePosition  : PropTypes.oneOf( [ 'top', 'topLeft' ] ),
-        /**
-         * Initial input string value
-         */
-        defaultValue          : PropTypes.string,
-        /**
-         * Input string value
-         */
-        value                 : PropTypes.string,
-        /**
-         * HTML id attribute (overwrite default)
-         */
-        id                    : PropTypes.string,
-        /**
-         *  HTML name attribute
-         */
-        name                  : PropTypes.string,
-        /**
-         *  Alignment of the show/hide icon
-         */
-        iconPosition          : PropTypes.oneOf( [ 'left', 'right' ] ),
-        /**
-         * Input text alignment
-         */
-        textAlign             : PropTypes.oneOf( [ 'auto', 'left', 'right' ] ),
-        /**
-         *  Input change callback function
-         */
-        onChange              : PropTypes.func,
-        /**
-         *  input callback function
-         */
-        onInput               : PropTypes.func,
-        /**
-         * keyPress callback function
-         */
-        onKeyPress            : PropTypes.func,
-        /**
-         *  focus callback function
-         */
-        onFocus               : PropTypes.func,
-        /**
-         *  blur callback function
-         */
-        onBlur                : PropTypes.func,
-        /**
-         *  mouseOver callback function
-         */
-        onMouseOver           : PropTypes.func,
-        /**
-         *  mouseOut callback function
-         */
-        onMouseOut            : PropTypes.func,
-        /**
-         *  Icon click callback function
-         */
-        onClickIcon           : PropTypes.func,
-        /**
-         *  Icon focus callback function
-         */
-        onFocusIcon           : PropTypes.func,
-        /**
-         *  Icon blur callback function
-         */
-        onBlurIcon            : PropTypes.func,
-        /**
-         *  Icon mouseOver callback function
-         */
-        onMouseOverIcon       : PropTypes.func,
-        /**
-         *  Icon mouseOut callback function
-         */
-        onMouseOutIcon        : PropTypes.func,
-        /**
-         * Display as hover when required from another component
-         */
-        forceHover            : PropTypes.bool,
-        /**
-         * Callback that receives the native <input>: ( ref ) => { ... }
-         */
-        inputRef              : PropTypes.func,
-    };
+    /**
+     * Extra CSS class name
+     */
+    className             : PropTypes.string,
+    /**
+     *  CSS class map
+     */
+    cssMap                : PropTypes.objectOf( PropTypes.string ),
+    /**
+     *  Label text string or JSX node
+     */
+    label                 : PropTypes.node,
+    /**
+     *  alternates input and icon types accordingly.
+     */
+    passwordIsVisible     : PropTypes.bool,
+    /**
+     *  Label position
+     */
+    labelPosition         : PropTypes.oneOf( [ 'top', 'left', 'right' ] ),
+    /**
+     *  Placeholder text
+     */
+    placeholder           : PropTypes.string,
+    /**
+     *  Display as disabled/read-only
+     */
+    isDisabled            : PropTypes.bool,
+    /**
+     *  Display as read-only
+     */
+    isReadOnly            : PropTypes.bool,
+    /**
+     *  Display as error/invalid
+     */
+    hasError              : PropTypes.bool,
+    /**
+     *  Tooltip message text (string or JSX)
+     */
+    errorMessage          : PropTypes.node,
+    /**
+     *  Tooltip is displayed
+     */
+    errorMessageIsVisible : PropTypes.bool,
+    /**
+     *  Error message position relative to the icon
+     */
+    errorMessagePosition  : PropTypes.oneOf( [ 'top', 'topLeft' ] ),
+    /**
+     * Initial input string value
+     */
+    defaultValue          : PropTypes.string,
+    /**
+     * Input string value
+     */
+    value                 : PropTypes.string,
+    /**
+     * HTML id attribute (overwrite default)
+     */
+    id                    : PropTypes.string,
+    /**
+     *  HTML name attribute
+     */
+    name                  : PropTypes.string,
+    /**
+     *  Alignment of the show/hide icon
+     */
+    iconPosition          : PropTypes.oneOf( [ 'left', 'right' ] ),
+    /**
+     * Input text alignment
+     */
+    textAlign             : PropTypes.oneOf( [ 'auto', 'left', 'right' ] ),
+    /**
+     *  Input change callback function
+     */
+    onChange              : PropTypes.func,
+    /**
+     *  input callback function
+     */
+    onInput               : PropTypes.func,
+    /**
+     * keyPress callback function
+     */
+    onKeyPress            : PropTypes.func,
+    /**
+     *  focus callback function
+     */
+    onFocus               : PropTypes.func,
+    /**
+     *  blur callback function
+     */
+    onBlur                : PropTypes.func,
+    /**
+     *  mouseOver callback function
+     */
+    onMouseOver           : PropTypes.func,
+    /**
+     *  mouseOut callback function
+     */
+    onMouseOut            : PropTypes.func,
+    /**
+     *  Icon click callback function
+     */
+    onClickIcon           : PropTypes.func,
+    /**
+     *  Icon focus callback function
+     */
+    onFocusIcon           : PropTypes.func,
+    /**
+     *  Icon blur callback function
+     */
+    onBlurIcon            : PropTypes.func,
+    /**
+     *  Icon mouseOver callback function
+     */
+    onMouseOverIcon       : PropTypes.func,
+    /**
+     *  Icon mouseOut callback function
+     */
+    onMouseOutIcon        : PropTypes.func,
+    /**
+     * Display as hover when required from another component
+     */
+    forceHover            : PropTypes.bool,
+    /**
+     * Callback that receives the native <input>: ( ref ) => { ... }
+     */
+    inputRef              : PropTypes.func,
+};
 
-    static defaultProps =
-    {
-        labelPosition         : 'top',
-        id                    : undefined,
-        isDisabled            : false,
-        isReadOnly            : false,
-        hasError              : false,
-        errorMessageIsVisible : false,
-        errorMessagePosition  : 'top',
-        iconPosition          : 'right',
-        textAlign             : 'auto',
-        forceHover            : false,
-        cssMap                : require( './passwordInput.css' ),
-    };
+PasswordInput.defaultProps =
+{
+    className             : undefined,
+    cssMap                : styles,
+    defaultValue          : undefined,
+    errorMessage          : undefined,
+    errorMessageIsVisible : false,
+    errorMessagePosition  : 'top',
+    forceHover            : false,
+    hasError              : false,
+    iconPosition          : 'right',
+    id                    : undefined,
+    inputRef              : undefined,
+    isDisabled            : false,
+    isReadOnly            : false,
+    label                 : undefined,
+    labelPosition         : 'top',
+    name                  : undefined,
+    onBlur                : undefined,
+    onBlurIcon            : undefined,
+    onChange              : undefined,
+    onClickIcon           : undefined,
+    onFocus               : undefined,
+    onInput               : undefined,
+    onKeyPress            : undefined,
+    onMouseOut            : undefined,
+    onMouseOutIcon        : undefined,
+    onMouseOver           : undefined,
+    onMouseOverIcon       : undefined,
+    passwordIsVisible     : undefined,
+    placeholder           : undefined,
+    textAlign             : 'auto',
+    value                 : undefined,
+};
 
-    render()
-    {
-        const {
-            className,
-            cssMap,
-            id = generateId( 'PasswordInput' ),
-            passwordIsVisible,
-            ...props
-        } = this.props;
-
-        return (
-            <TextInputWithIcon
-                { ...props }
-                className = { buildClassName( className, cssMap ) }
-                id        = { id }
-                inputType = { passwordIsVisible ? 'text' : 'password' }
-                iconType  = { passwordIsVisible ? 'hide' : 'show' } />
-        );
-    }
-}
+export default PasswordInput;

--- a/src/PasswordInput/tests.jsx
+++ b/src/PasswordInput/tests.jsx
@@ -7,7 +7,6 @@ import { ReactWrapper, mount, shallow } from 'enzyme';
 
 import { TextInputWithIcon }            from '../index';
 
-
 import PasswordInput                    from './index';
 
 
@@ -22,23 +21,15 @@ describe( 'PasswordInput', () =>
         instance = wrapper.instance();
     } );
 
-    describe( 'constructor( props )', () =>
+    test( 'should be an instance of StatelessComponent', () =>
     {
-        test( 'should have name PasswordInput', () =>
-        {
-            expect( instance.constructor.name ).toBe( 'PasswordInput' );
-        } );
+        expect( instance.constructor.name ).toBe( 'StatelessComponent' );
     } );
 
-    describe( 'render()', () =>
+    test( 'should contain exactly one TextInputWithIcon', () =>
     {
-
-        test( 'should contain exactly one TextInputWithIcon', () =>
-        {
-            expect( wrapper.find( TextInputWithIcon ) ).toHaveLength( 1 );
-        } );
+        expect( wrapper.find( TextInputWithIcon ) ).toHaveLength( 1 );
     } );
-
 
     test( 'it should pass inputType "password" by default', () =>
     {
@@ -87,7 +78,7 @@ describe( 'PasswordInputDriver', () =>
             wrapper.setProps( {
                 hasError              : true,
                 errorMessage          : <h2>Pikachu!</h2>,
-                errorMessageIsVisible : true
+                errorMessageIsVisible : true,
             } );
         } );
 
@@ -111,7 +102,7 @@ describe( 'PasswordInputDriver', () =>
             wrapper.setProps( {
                 title    : 'Test',
                 hasError : false,
-                onFocus  : focusSpy
+                onFocus  : focusSpy,
             } );
 
             driver.focus();
@@ -127,7 +118,7 @@ describe( 'PasswordInputDriver', () =>
             wrapper.setProps( {
                 title    : 'Test',
                 hasError : false,
-                onBlur   : blurSpy
+                onBlur   : blurSpy,
             } );
 
             driver.blur();
@@ -143,7 +134,7 @@ describe( 'PasswordInputDriver', () =>
             wrapper.setProps( {
                 title    : 'Test',
                 hasError : false,
-                onChange : changeSpy
+                onChange : changeSpy,
             } );
 
             driver.setInputValue( 'test' );
@@ -158,7 +149,7 @@ describe( 'PasswordInputDriver', () =>
             const keyCodeEnter = 13;
             const keyPressSpy = jest.fn();
             wrapper.setProps( {
-                onKeyPress : keyPressSpy
+                onKeyPress : keyPressSpy,
             } );
 
             driver.pressKey( keyCodeEnter );
@@ -170,7 +161,7 @@ describe( 'PasswordInputDriver', () =>
             const keyCodeChar = String.fromCharCode( 74 );
             const onChangeSpy = jest.fn();
             wrapper.setProps( {
-                onChange : onChangeSpy
+                onChange : onChangeSpy,
             } );
 
             driver.pressKey( keyCodeChar );
@@ -183,7 +174,7 @@ describe( 'PasswordInputDriver', () =>
             const onChangeSpy = jest.fn();
             wrapper.setProps( {
                 onKeyPress : keyPressSpy,
-                onChange   : onChangeSpy
+                onChange   : onChangeSpy,
             } );
 
             driver.inputValue( 'Harry Potter' );
@@ -207,7 +198,7 @@ describe( 'PasswordInputDriver', () =>
             wrapper.setProps( {
                 label      : 'test',
                 isDisabled : true,
-                onClick    : clickSpy
+                onClick    : clickSpy,
             } );
 
             const expectedError =

--- a/src/Section/index.jsx
+++ b/src/Section/index.jsx
@@ -6,63 +6,72 @@ import H1                               from '../H1';
 import H2                               from '../H2';
 import H3                               from '../H3';
 import H4                               from '../H4';
+import styles                           from './section.css';
 
-const headers = {
-    1 : H1, 2 : H2, 3 : H3, 4 : H4
+const headers = { 1: H1, 2: H2, 3: H3, 4 : H4 };
+
+
+const Section = ( {
+    children,
+    className,
+    cssMap,
+    id = generateId( 'Section' ),
+    level,
+    title,
+} ) =>
+{
+    const SectionHeader = headers[ level ];
+
+    return (
+        <section
+            className = { buildClassName( className, cssMap, {  level } ) }
+            id        = { id }>
+            { title && SectionHeader &&
+                <SectionHeader>{ title }</SectionHeader>
+            }
+            <div className = { cssMap.content }>
+                { children }
+            </div>
+        </section>
+    );
 };
 
-export default class Section extends React.PureComponent
+Section.propTypes =
 {
-    static propTypes =
-    {
-        /**
-         * HTML id attribute (overwrite default)
-         */
-        id       : PropTypes.string,
-        /**
-         *  Section title
-         */
-        title    : PropTypes.string,
-        /**
-         *  Section content
-         */
-        children : PropTypes.node,
-        /**
-         *  Section level in the document outline
-         */
-        level    : PropTypes.number
-    };
+    /**
+     * Section content
+     */
+    children  : PropTypes.node,
+    /**
+     * Extra CSS class name
+     */
+    className : PropTypes.string,
+    /**
+     *  CSS class map
+     */
+    cssMap    : PropTypes.objectOf( PropTypes.string ),
+    /**
+     * HTML id attribute (overwrite default)
+     */
+    id        : PropTypes.string,
+    /**
+     *  Section title
+     */
+    title     : PropTypes.string,
+    /**
+     *  Section level in the document outline
+     */
+    level     : PropTypes.number,
+};
 
-    static defaultProps =
-    {
-        hasDivider : false,
-        id         : undefined,
-        cssMap     : require( './section.css' )
-    };
+Section.defaultProps =
+{
+    children  : undefined,
+    className : undefined,
+    cssMap    : styles,
+    id        : undefined,
+    level     : undefined,
+    title     : undefined,
+};
 
-    render()
-    {
-        const {
-            cssMap,
-            className,
-            children,
-            id = generateId( 'Section' ),
-            level,
-            title
-        } = this.props;
-
-        const SectionHeader = headers[ level ];
-
-        return (
-
-            <section className = { buildClassName( className, cssMap, { level } ) } id = { id }>
-                { title && SectionHeader &&
-                <SectionHeader>{ title }</SectionHeader>
-                }
-                <div className = { cssMap.content }>
-                    { children }
-                </div>
-            </section>
-        );
-    }
-}
+export default Section;

--- a/src/Section/tests.jsx
+++ b/src/Section/tests.jsx
@@ -4,10 +4,10 @@
 import React              from 'react';
 import { mount, shallow } from 'enzyme';
 
-
 import { H1, H4 }         from '../index';
 
 import Section            from './index';
+
 
 describe( 'Section', () =>
 {
@@ -20,29 +20,19 @@ describe( 'Section', () =>
         instance = wrapper.instance();
     } );
 
-    describe( 'constructor( props )', () =>
+    test( 'should be an instance of StatelessComponent', () =>
     {
-        test( 'should have name Button', () =>
-        {
-            expect( instance.constructor.name ).toBe( 'Section' );
-        } );
+        expect( instance.constructor.name ).toBe( 'StatelessComponent' );
     } );
 
-    describe( 'render()', () =>
+    test( 'should have a header component corresponding to level prop', () =>
     {
-      
-        test(
-            'should have a header component corresponding to level prop',
-            () =>
-            {
-                wrapper.setProps( {
-                    title : 'Boom',
-                    level : 4
-                } );
+        wrapper.setProps( {
+            title : 'Boom',
+            level : 4,
+        } );
 
-                expect( wrapper.find( H4 ) ).toHaveLength( 1 );
-            }
-        );
+        expect( wrapper.find( H4 ) ).toHaveLength( 1 );
     } );
 
     describe( 'props', () =>
@@ -58,7 +48,7 @@ describe( 'Section', () =>
             {
                 wrapper.setProps( {
                     title : 'Boom',
-                    level : 1
+                    level : 1,
                 } );
 
                 expect( wrapper.find( H1 ).prop( 'children' ) ).toBe( 'Boom' );

--- a/src/SpriteMap/index.jsx
+++ b/src/SpriteMap/index.jsx
@@ -1,38 +1,32 @@
-import React            from 'react';
-import PropTypes        from 'prop-types';
+import React          from 'react';
+import PropTypes      from 'prop-types';
 
-import spriteHtml       from '../Icon/sprite.html';
-import { generateId, buildClassName }   from '../utils';
+import spriteHtml     from '../Icon/sprite.html';
+import { generateId } from '../utils';
 
 
-export default class SpriteMap extends React.PureComponent
+const SpriteMap = ( {
+    id = generateId( 'SpriteMap' ),
+    spriteTemplate = { __html: spriteHtml },
+} ) => (
+    <div id = { id } dangerouslySetInnerHTML = { spriteTemplate } />
+);
+
+SpriteMap.propTypes =
 {
-    static propTypes =
-    {
-        /**
-         * HTML id attribute (overwrite default)
-         */
-        id             : PropTypes.string,
-        /**
-         * builds sprites
-         */
-        spriteTemplate : PropTypes.func
-    };
+    /**
+     * HTML id attribute (overwrite default)
+     */
+    id             : PropTypes.string,
+    /**
+     * Custom SVG sprite
+     */
+    spriteTemplate : PropTypes.shape( { __html: PropTypes.string } ),
+};
 
-    static defaultProps =
-    {
-        id : undefined
-    };
+SpriteMap.defaultProps =
+{
+    id : undefined,
+};
 
-    render()
-    {
-        const {
-            spriteTemplate = { __html: spriteHtml },
-            id = generateId( 'SpriteMap' )
-        } = this.props;
-
-        return (
-            <div id = { id } dangerouslySetInnerHTML = { spriteTemplate } />
-        );
-    }
-}
+export default SpriteMap;

--- a/src/Tab/index.jsx
+++ b/src/Tab/index.jsx
@@ -1,57 +1,63 @@
-import React                            from 'react';
-import PropTypes                        from 'prop-types';
+import React                          from 'react';
+import PropTypes                      from 'prop-types';
 
-import { generateId, buildClassName }   from '../utils';
+import { generateId, buildClassName } from '../utils';
+import styles                         from './tab.css';
 
+const Tab = ( {
+    children,
+    className,
+    cssMap,
+    id = generateId( 'Tab' ),
+    label,
+    onClick,
+} ) => (
+    <div
+        className  = { buildClassName( className, cssMap ) }
+        onClick    = { onClick }
+        aria-label = { label }
+        id         = { id }
+        role       = "tabpanel">
+        { children }
+    </div>
+);
 
-export default class Tab extends React.PureComponent
+Tab.propTypes =
 {
-    static propTypes =
-    {
-        /**
-        *  Contents of the Tab
-        */
-        children : PropTypes.node,
-        /**
-         * HTML id attribute (overwrite default)
-         */
-        id       : PropTypes.string,
-        /**
-        *  Label to show in TabButton of this tab
-        */
-        label    : PropTypes.string,
-        /**
-        *  onClick callback function: ( e ) => { ... }
-        */
-        onClick  : PropTypes.func
-    };
+    /**
+     * Section content
+     */
+    children  : PropTypes.node,
+    /**
+     * Extra CSS class name
+     */
+    className : PropTypes.string,
+    /**
+     *  CSS class map
+     */
+    cssMap    : PropTypes.objectOf( PropTypes.string ),
+    /**
+     * HTML id attribute (overwrite default)
+     */
+    id        : PropTypes.string,
+    /**
+    *  Label to show in TabButton of this tab
+    */
+    label     : PropTypes.string,
+    /**
+    *  onClick callback function: ( e ) => { ... }
+    */
+    onClick   : PropTypes.func,
+};
 
-    static defaultProps =
-    {
-        cssMap : require( './tab.css' ),
-        id     : undefined
-    };
+Tab.defaultProps =
+{
+    children  : undefined,
+    className : undefined,
+    cssMap    : styles,
+    id        : undefined,
+    label     : undefined,
+    onClick   : undefined,
+};
 
-    render()
-    {
-        const {
-            cssMap,
-            children,
-            className,
-            id = generateId( 'Tab' ),
-            onClick,
-            label
-        } = this.props;
-
-        return (
-            <div
-                className  = { buildClassName( className, cssMap ) }
-                onClick    = { onClick }
-                aria-label = { label }
-                id         = { id }
-                role       = "tabpanel">
-                { children }
-            </div>
-        );
-    }
-}
+export default Tab;

--- a/src/TextArea/index.jsx
+++ b/src/TextArea/index.jsx
@@ -1,152 +1,166 @@
-import React                            from 'react';
-import PropTypes                        from 'prop-types';
+import React                          from 'react';
+import PropTypes                      from 'prop-types';
 
-import { generateId, buildClassName }   from '../utils';
-import InputField                       from '../InputField';
-import InputContainer                   from '../proto/InputContainer';
+import { generateId, buildClassName } from '../utils';
+import InputField                     from '../InputField';
+import InputContainer                 from '../proto/InputContainer';
+import styles                         from './textArea.css';
 
 
-export default class TextArea extends React.PureComponent
+const TextArea = ( {
+    className,
+    cssMap,
+    id = generateId( 'TextArea' ),
+    onMouseOut,
+    onMouseOver,
+    ...props
+} ) => (
+    <InputContainer
+        { ...props }
+        className   = { buildClassName( className, cssMap ) }
+        id          = { id }
+        onMouseOut  = { onMouseOut }
+        onMouseOver = { onMouseOver }>
+        <InputField { ...props } id = { id } element = "textarea" />
+    </InputContainer>
+);
+
+TextArea.propTypes =
 {
-    static propTypes =
-    {
-        /**
-         *  Label text (string or JSX node)
-         */
-        label                 : PropTypes.node,
-        /**
-         *  Label position
-         */
-        labelPosition         : PropTypes.oneOf( [ 'top', 'left', 'right' ] ),
-        /**
-         *  Placeholder text
-         */
-        placeholder           : PropTypes.string,
-        /**
-         *  Number of text input rows
-         */
-        rows                  : PropTypes.number,
-        /**
-          * Sets the text area to be vertically resizable
-          */
-        isResizable           : PropTypes.bool,
-        /**
-         *  Alignment of the input text
-         */
-        textAlign             : PropTypes.oneOf( [ 'left', 'right' ] ),
-        /**
-         *  Display as disabled
-         */
-        isDisabled            : PropTypes.bool,
-        /**
-         *  Display as read-only
-         */
-        isReadOnly            : PropTypes.bool,
-        /**
-         *  Display as error/invalid
-         */
-        hasError              : PropTypes.bool,
-        /**
-         *  Error tooltip message text (string or JSX)
-         */
-        errorMessage          : PropTypes.node,
-        /**
-         *  Error Tooltip is displayed
-         */
-        errorMessageIsVisible : PropTypes.bool,
-        /**
-        *  Error message position relative to the icon
-        */
-        errorMessagePosition  : PropTypes.oneOf( [ 'top', 'topLeft' ] ),
-        /**
-         * Initial input string value
-         */
-        defaultValue          : PropTypes.string,
-        /**
-         * Input string value
-         */
-        value                 : PropTypes.string,
-        /**
-         * HTML id attribute (overwrite default)
-         */
-        id                    : PropTypes.string,
-        /**
-         *  HTML name attribute
-         */
-        name                  : PropTypes.string,
-        /**
-         *  Input change callback function
-         */
-        onChange              : PropTypes.func,
-        /**
-         *  Input click callback function
-         */
-        onClick               : PropTypes.func,
-        /**
-         *  Input focus callback function
-         */
-        onFocus               : PropTypes.func,
-        /**
-         *  Input blur callback function
-         */
-        onBlur                : PropTypes.func,
-        /**
-         *  Input mouseOver callback function
-         */
-        onMouseOver           : PropTypes.func,
-        /**
-         *  Input mouseOut callback function
-         */
-        onMouseOut            : PropTypes.func,
-        /**
-         * Display as hover when required from another component
-         */
-        forceHover            : PropTypes.bool,
-        /**
-         * Callback that receives the native <textarea>: ( ref ) => { ... }
-         */
-        inputRef              : PropTypes.func,
-    };
+    /**
+     * Extra CSS class name
+     */
+    className             : PropTypes.string,
+    /**
+     *  CSS class map
+     */
+    cssMap                : PropTypes.objectOf( PropTypes.string ),
+    /**
+     *  Label text (string or JSX node)
+     */
+    label                 : PropTypes.node,
+    /**
+     *  Label position
+     */
+    labelPosition         : PropTypes.oneOf( [ 'top', 'left', 'right' ] ),
+    /**
+     *  Placeholder text
+     */
+    placeholder           : PropTypes.string,
+    /**
+     *  Number of text input rows
+     */
+    rows                  : PropTypes.number,
+    /**
+      * Sets the text area to be vertically resizable
+      */
+    isResizable           : PropTypes.bool,
+    /**
+     *  Alignment of the input text
+     */
+    textAlign             : PropTypes.oneOf( [ 'left', 'right' ] ),
+    /**
+     *  Display as disabled
+     */
+    isDisabled            : PropTypes.bool,
+    /**
+     *  Display as read-only
+     */
+    isReadOnly            : PropTypes.bool,
+    /**
+     *  Display as error/invalid
+     */
+    hasError              : PropTypes.bool,
+    /**
+     *  Error tooltip message text (string or JSX)
+     */
+    errorMessage          : PropTypes.node,
+    /**
+     *  Error Tooltip is displayed
+     */
+    errorMessageIsVisible : PropTypes.bool,
+    /**
+    *  Error message position relative to the icon
+    */
+    errorMessagePosition  : PropTypes.oneOf( [ 'top', 'topLeft' ] ),
+    /**
+     * Initial input string value
+     */
+    defaultValue          : PropTypes.string,
+    /**
+     * Input string value
+     */
+    value                 : PropTypes.string,
+    /**
+     * HTML id attribute (overwrite default)
+     */
+    id                    : PropTypes.string,
+    /**
+     *  HTML name attribute
+     */
+    name                  : PropTypes.string,
+    /**
+     *  Input change callback function
+     */
+    onChange              : PropTypes.func,
+    /**
+     *  Input click callback function
+     */
+    onClick               : PropTypes.func,
+    /**
+     *  Input focus callback function
+     */
+    onFocus               : PropTypes.func,
+    /**
+     *  Input blur callback function
+     */
+    onBlur                : PropTypes.func,
+    /**
+     *  Input mouseOver callback function
+     */
+    onMouseOver           : PropTypes.func,
+    /**
+     *  Input mouseOut callback function
+     */
+    onMouseOut            : PropTypes.func,
+    /**
+     * Display as hover when required from another component
+     */
+    forceHover            : PropTypes.bool,
+    /**
+     * Callback that receives the native <textarea>: ( ref ) => { ... }
+     */
+    inputRef              : PropTypes.func,
+};
 
-    static defaultProps =
-    {
-        labelPosition         : 'top',
-        rows                  : 3,
-        id                    : undefined,
-        isResizable           : true,
-        isDisabled            : false,
-        isReadOnly            : false,
-        hasError              : false,
-        errorMessageIsVisible : false,
-        errorMessagePosition  : 'top',
-        textAlign             : 'left',
-        forceHover            : false,
-        cssMap                : require( './textArea.css' )
-    };
+TextArea.defaultProps =
+{
+    className             : undefined,
+    cssMap                : styles,
+    defaultValue          : undefined,
+    errorMessage          : undefined,
+    errorMessageIsVisible : false,
+    errorMessagePosition  : 'top',
+    forceHover            : false,
+    hasError              : false,
+    id                    : undefined,
+    inputRef              : undefined,
+    isDisabled            : false,
+    isReadOnly            : false,
+    isResizable           : true,
+    label                 : undefined,
+    labelPosition         : 'top',
+    name                  : undefined,
+    onBlur                : undefined,
+    onChange              : undefined,
+    onClick               : undefined,
+    onFocus               : undefined,
+    onMouseOut            : undefined,
+    onMouseOver           : undefined,
+    placeholder           : undefined,
+    rows                  : 3,
+    textAlign             : 'left',
+    value                 : undefined,
+};
 
-
-    render()
-    {
-        const {
-            className,
-            cssMap,
-            id = generateId( 'TextArea' ),
-            onMouseOut,
-            onMouseOver,
-            ...props
-        } = this.props;
-
-        return (
-
-            <InputContainer
-                { ...props }
-                className   = { buildClassName( className, cssMap ) }
-                id          = { id }
-                onMouseOut  = { onMouseOut }
-                onMouseOver = { onMouseOver }>
-                <InputField { ...props } id = { id } element = "textarea" />
-            </InputContainer>
-
-        );
-    }
-}
+export default TextArea;

--- a/src/TextArea/tests.jsx
+++ b/src/TextArea/tests.jsx
@@ -8,7 +8,6 @@ import { shallow }      from 'enzyme';
 import { InputField }   from '../index';
 import InputContainer   from '../proto/InputContainer';
 
-
 import TextArea         from './index';
 
 
@@ -23,31 +22,24 @@ describe( 'TextArea', () =>
         instance = wrapper.instance();
     } );
 
-    describe( 'constructor( props )', () =>
+    test( 'should be an instance of StatelessComponent', () =>
     {
-        test( 'should have name TextArea', () =>
-        {
-            expect( instance.constructor.name ).toBe( 'TextArea' );
-        } );
+        expect( instance.constructor.name ).toBe( 'StatelessComponent' );
     } );
 
-    describe( 'render()', () =>
+    test( 'should contain exactly one InputContainer', () =>
     {
+        expect( wrapper.find( InputContainer ) ).toHaveLength( 1 );
+    } );
 
-        test( 'should contain exactly one InputContainer', () =>
-        {
-            expect( wrapper.find( InputContainer ) ).toHaveLength( 1 );
-        } );
+    test( 'should contain exactly one InputField', () =>
+    {
+        expect( wrapper.find( InputField ) ).toHaveLength( 1 );
+    } );
 
-        test( 'should contain exactly one InputField', () =>
-        {
-            expect( wrapper.find( InputField ) ).toHaveLength( 1 );
-        } );
-
-        test( 'InputField should have element="textarea"', () =>
-        {
-            expect( wrapper.find( InputField ).prop( 'element' ) )
-                .toBe( 'textarea' );
-        } );
+    test( 'InputField should have element="textarea"', () =>
+    {
+        expect( wrapper.find( InputField ).prop( 'element' ) )
+            .toBe( 'textarea' );
     } );
 } );

--- a/src/TextInput/index.jsx
+++ b/src/TextInput/index.jsx
@@ -4,160 +4,166 @@ import PropTypes                        from 'prop-types';
 import { generateId, buildClassName }   from '../utils';
 import InputField                       from '../InputField';
 import InputContainer                   from '../proto/InputContainer';
+import styles                           from './textInput.css';
 
-export default class TextInput extends React.PureComponent
+
+const TextInput = ( {
+    className,
+    cssMap,
+    id = generateId( 'TextInput' ),
+    onMouseOut,
+    onMouseOver,
+    ...props
+} ) => (
+    <InputContainer
+        { ...props }
+        id          = { id }
+        className   = { buildClassName( className, cssMap ) }
+        onMouseOut  = { onMouseOut }
+        onMouseOver = { onMouseOver }>
+        <InputField { ...props } id = { id } />
+    </InputContainer>
+);
+
+TextInput.propTypes =
 {
-    static propTypes =
-    {
-        /**
-         *  aria properties
-         */
-        aria : PropTypes.objectOf( PropTypes.oneOfType( [
-            PropTypes.bool,
-            PropTypes.number,
-            PropTypes.string,
-        ] ) ),
-        /**
-         *  Label text (string or JSX node)
-         */
-        label         : PropTypes.node,
-        /**
-         *  Label position
-         */
-        labelPosition : PropTypes.oneOf( [
-            'top',
-            'left',
-            'right'
-        ] ),
-        /**
-         *  Placeholder text
-         */
-        placeholder : PropTypes.string,
-        /**
-         *  Alignment of the input text
-         */
-        textAlign   : PropTypes.oneOf( [
-            'left',
-            'right'
-        ] ),
-        /**
-         *  Display as disabled
-         */
-        isDisabled            : PropTypes.bool,
-        /**
-         *  Display as read-only
-         */
-        isReadOnly            : PropTypes.bool,
-        /**
-         *  Display as error/invalid
-         */
-        hasError              : PropTypes.bool,
-        /**
-         *  Tooltip message text (string or JSX)
-         */
-        errorMessage          : PropTypes.node,
-        /**
-         *  Error Tooltip is displayed
-         */
-        errorMessageIsVisible : PropTypes.bool,
-        /**
-        *  Error message position relative to the icon
-        */
-        errorMessagePosition  : PropTypes.oneOf( [ 'top', 'topLeft' ] ),
-        /**
-         *  Initial input string value
-         */
-        defaultValue          : PropTypes.string,
-        /**
-         *  Input string value
-         */
-        value                 : PropTypes.string,
-        /**
-         *  HTML id attribute (overwrite default)
-         */
-        id                    : PropTypes.string,
-        /**
-         *  HTML name attribute
-         */
-        name                  : PropTypes.string,
-        /**
-         *  Input click callback function
-         */
-        onClick               : PropTypes.func,
-        /**
-         *  Input change callback function
-         */
-        onChange              : PropTypes.func,
-        /**
-         *  Input focus callback function
-         */
-        onFocus               : PropTypes.func,
-        /**
-         *  Input blur callback function
-         */
-        onBlur                : PropTypes.func,
-        /**
-         * onInput callback function
-         */
-        onInput               : PropTypes.func,
-        /**
-         * onKeyPress callback function
-         */
-        onKeyPress            : PropTypes.func,
-        /**
-         *  Input mouseOver callback function
-         */
-        onMouseOver           : PropTypes.func,
-        /**
-         *  Input mouseOut callback function
-         */
-        onMouseOut            : PropTypes.func,
-        /**
-         * Display as hover when required from another component
-         */
-        forceHover            : PropTypes.bool,
-        /**
-         * Callback that receives the native <input>: ( ref ) => { ... }
-         */
-        inputRef              : PropTypes.func,
-    };
+    /**
+     *  aria properties
+     */
+    aria : PropTypes.objectOf( PropTypes.oneOfType( [
+        PropTypes.bool,
+        PropTypes.number,
+        PropTypes.string,
+    ] ) ),
+    /**
+     *  CSS class map
+     */
+    cssMap                : PropTypes.objectOf( PropTypes.string ),
+    /**
+     *  Label text (string or JSX node)
+     */
+    label                 : PropTypes.node,
+    /**
+     *  Label position
+     */
+    labelPosition         : PropTypes.oneOf( [ 'top', 'left', 'right' ] ),
+    /**
+     *  Placeholder text
+     */
+    placeholder           : PropTypes.string,
+    /**
+     *  Alignment of the input text
+     */
+    textAlign             : PropTypes.oneOf( [ 'left', 'right' ] ),
+    /**
+     *  Display as disabled
+     */
+    isDisabled            : PropTypes.bool,
+    /**
+     *  Display as read-only
+     */
+    isReadOnly            : PropTypes.bool,
+    /**
+     *  Display as error/invalid
+     */
+    hasError              : PropTypes.bool,
+    /**
+     *  Tooltip message text (string or JSX)
+     */
+    errorMessage          : PropTypes.node,
+    /**
+     *  Error Tooltip is displayed
+     */
+    errorMessageIsVisible : PropTypes.bool,
+    /**
+    *  Error message position relative to the icon
+    */
+    errorMessagePosition  : PropTypes.oneOf( [ 'top', 'topLeft' ] ),
+    /**
+     *  Initial input string value
+     */
+    defaultValue          : PropTypes.string,
+    /**
+     *  Input string value
+     */
+    value                 : PropTypes.string,
+    /**
+     *  HTML id attribute (overwrite default)
+     */
+    id                    : PropTypes.string,
+    /**
+     *  HTML name attribute
+     */
+    name                  : PropTypes.string,
+    /**
+     *  Input click callback function
+     */
+    onClick               : PropTypes.func,
+    /**
+     *  Input change callback function
+     */
+    onChange              : PropTypes.func,
+    /**
+     *  Input focus callback function
+     */
+    onFocus               : PropTypes.func,
+    /**
+     *  Input blur callback function
+     */
+    onBlur                : PropTypes.func,
+    /**
+     * onInput callback function
+     */
+    onInput               : PropTypes.func,
+    /**
+     * onKeyPress callback function
+     */
+    onKeyPress            : PropTypes.func,
+    /**
+     *  Input mouseOver callback function
+     */
+    onMouseOver           : PropTypes.func,
+    /**
+     *  Input mouseOut callback function
+     */
+    onMouseOut            : PropTypes.func,
+    /**
+     * Display as hover when required from another component
+     */
+    forceHover            : PropTypes.bool,
+    /**
+     * Callback that receives the native <input>: ( ref ) => { ... }
+     */
+    inputRef              : PropTypes.func,
+};
 
-    static defaultProps =
-    {
-        aria                  : undefined,
-        labelPosition         : 'top',
-        id                    : undefined,
-        isDisabled            : false,
-        isReadOnly            : false,
-        hasError              : false,
-        errorMessageIsVisible : false,
-        errorMessagePosition  : 'top',
-        forceHover            : false,
-        cssMap                : require( './textInput.css' )
-    };
+TextInput.defaultProps =
+{
+    aria                  : undefined,
+    cssMap                : styles,
+    defaultValue          : undefined,
+    errorMessage          : undefined,
+    errorMessageIsVisible : false,
+    errorMessagePosition  : 'top',
+    forceHover            : false,
+    hasError              : false,
+    id                    : undefined,
+    inputRef              : undefined,
+    isDisabled            : false,
+    isReadOnly            : false,
+    label                 : undefined,
+    labelPosition         : 'top',
+    name                  : undefined,
+    onBlur                : undefined,
+    onChange              : undefined,
+    onClick               : undefined,
+    onFocus               : undefined,
+    onInput               : undefined,
+    onKeyPress            : undefined,
+    onMouseOut            : undefined,
+    onMouseOver           : undefined,
+    textAlign             : undefined,
+    value                 : undefined,
+};
 
-
-    render()
-    {
-        const {
-            className,
-            cssMap,
-            id = generateId( 'TextInput' ),
-            onMouseOut,
-            onMouseOver,
-            ...props
-        } = this.props;
-
-        return (
-
-            <InputContainer
-                { ...props }
-                id          = { id }
-                className   = { buildClassName( className, cssMap ) }
-                onMouseOut  = { onMouseOut }
-                onMouseOver = { onMouseOver }>
-                <InputField { ...props } id = { id } />
-            </InputContainer>
-        );
-    }
-}
+export default TextInput;

--- a/src/TextInput/tests.jsx
+++ b/src/TextInput/tests.jsx
@@ -8,7 +8,6 @@ import { mount, shallow } from 'enzyme';
 import { InputField }     from '../index';
 import InputContainer     from '../proto/InputContainer';
 
-
 import TextInput          from './index';
 
 
@@ -23,26 +22,19 @@ describe( 'TextInput', () =>
         instance = wrapper.instance();
     } );
 
-    describe( 'constructor( props )', () =>
+    test( 'should be an instance of StatelessComponent', () =>
     {
-        test( 'should have name TextInput', () =>
-        {
-            expect( instance.constructor.name ).toBe( 'TextInput' );
-        } );
+        expect( instance.constructor.name ).toBe( 'StatelessComponent' );
     } );
 
-    describe( 'render()', () =>
+    test( 'should contain exactly one InputContainer', () =>
     {
-  
-        test( 'should contain exactly one InputContainer', () =>
-        {
-            expect( wrapper.find( InputContainer ) ).toHaveLength( 1 );
-        } );
+        expect( wrapper.find( InputContainer ) ).toHaveLength( 1 );
+    } );
 
-        test( 'should contain exactly one InputField', () =>
-        {
-            expect( wrapper.find( InputField ) ).toHaveLength( 1 );
-        } );
+    test( 'should contain exactly one InputField', () =>
+    {
+        expect( wrapper.find( InputField ) ).toHaveLength( 1 );
     } );
 } );
 
@@ -66,7 +58,7 @@ describe( 'TextInputDriver', () =>
             wrapper.setProps( {
                 title    : 'Test',
                 hasError : false,
-                onBlur   : blurSpy
+                onBlur   : blurSpy,
             } );
 
             driver.blur();
@@ -105,7 +97,7 @@ describe( 'TextInputDriver', () =>
             wrapper.setProps( {
                 label      : 'test',
                 isDisabled : true,
-                onChange   : onChangeSpy
+                onChange   : onChangeSpy,
             } );
 
             const expectedError =
@@ -123,7 +115,7 @@ describe( 'TextInputDriver', () =>
             wrapper.setProps( {
                 label      : 'test',
                 isReadOnly : true,
-                onChange   : onChangeSpy
+                onChange   : onChangeSpy,
             } );
 
             const expectedError =
@@ -144,7 +136,7 @@ describe( 'TextInputDriver', () =>
             wrapper.setProps( {
                 label      : 'test',
                 isDisabled : true,
-                onChange   : onChangeSpy
+                onChange   : onChangeSpy,
             } );
 
             const expectedError =
@@ -162,7 +154,7 @@ describe( 'TextInputDriver', () =>
             wrapper.setProps( {
                 label      : 'test',
                 isReadOnly : true,
-                onChange   : onChangeSpy
+                onChange   : onChangeSpy,
             } );
 
             const expectedError =
@@ -203,7 +195,7 @@ describe( 'TextInputDriver', () =>
             const onChangeSpy = jest.fn();
             wrapper.setProps( {
                 onKeyPress : keyPressSpy,
-                onChange   : onChangeSpy
+                onChange   : onChangeSpy,
             } );
 
             driver.inputValue( 'Harry Potter' );
@@ -222,7 +214,7 @@ describe( 'TextInputDriver', () =>
             wrapper.setProps( {
                 label      : 'test',
                 isDisabled : true,
-                onKeyPress : keyPressSpy
+                onKeyPress : keyPressSpy,
             } );
 
             const expectedError =
@@ -240,7 +232,7 @@ describe( 'TextInputDriver', () =>
             wrapper.setProps( {
                 label      : 'test',
                 isReadOnly : true,
-                onKeyPress : keyPressSpy
+                onKeyPress : keyPressSpy,
             } );
 
             const expectedError =
@@ -261,7 +253,7 @@ describe( 'TextInputDriver', () =>
             wrapper.setProps( {
                 label      : 'test',
                 isDisabled : true,
-                onClick    : handleClickSpy
+                onClick    : handleClickSpy,
             } );
 
             const expectedError =
@@ -278,7 +270,7 @@ describe( 'TextInputDriver', () =>
             wrapper.setProps( {
                 label      : 'test',
                 isReadOnly : true,
-                onClick    : handleClickSpy
+                onClick    : handleClickSpy,
             } );
 
             const expectedError =

--- a/src/Tooltip/index.jsx
+++ b/src/Tooltip/index.jsx
@@ -1,171 +1,188 @@
-import React                            from 'react';
-import PropTypes                        from 'prop-types';
+import React                          from 'react';
+import PropTypes                      from 'prop-types';
 
-import { generateId, buildClassName }   from '../utils';
-import IconButton                       from '../IconButton';
-import Text                             from '../Text';
+import { generateId, buildClassName } from '../utils';
+import IconButton                     from '../IconButton';
+import Text                           from '../Text';
+import styles                         from './tooltip.css';
 
-export default class Tooltip extends React.PureComponent
+const Tooltip = ( {
+    children,
+    className,
+    cssMap,
+    id = generateId( 'Tooltip' ),
+    isDismissible,
+    isVisible,
+    message,
+    noWrap,
+    onClickClose,
+    onMouseOut,
+    onMouseOver,
+    overflowIsHidden,
+    position,
+    role,
+} ) =>
 {
-    static propTypes =
+    let messageText = message;
+
+    if ( typeof messageText === 'string' )
     {
-        /**
-         *  Node that the Tooltip wraps
-         */
-        children         : PropTypes.node,
-        /**
-         * HTML id attribute (overwrite default)
-         */
-        id               : PropTypes.string,
-        /**
-         *  Display the tooltip as user dismissible
-         */
-        isDismissible    : PropTypes.bool,
-        /**
-         *  Display the tooltip
-         */
-        isVisible        : PropTypes.bool,
-        /**
-         *  Tooltip message text (string or JSX)
-         */
-        message          : PropTypes.node,
-        /**
-         *  Text won’t wrap to the next line
-         */
-        noWrap           : PropTypes.bool,
-        /**
-         *  Function to call on “Close” button click: ( e ) => { ... }
-         */
-        onClickClose     : PropTypes.func,
-        /**
-         *  onMouseOver callback function: ( e ) => { ... }
-         */
-        onMouseOver      : PropTypes.func,
-        /**
-         *  onMouseOut callback function: ( e ) => { ... }
-         */
-        onMouseOut       : PropTypes.func,
-        /**
-         *  Hides overflow of wrapped content
-         */
-        overflowIsHidden : PropTypes.bool,
-        /**
-         *  Tooltip position relative to wrapped component
-         */
-        position         : PropTypes.oneOf( [
-            'left',
-            'right',
-            'top',
-            'bottom',
-            'topLeft',
-            'topRight',
-            'bottomLeft',
-            'bottomRight' ] ),
-        /**
-         *  Tooltip role/style
-         */
-        role : PropTypes.oneOf( [
-            'default',
-            'critical',
-            'promoted',
-            'warning'
-        ] )
-    };
+        const regexp = /([^\s].{1,49}(?=\s+|$))|([^\s]{1,50})/g;
 
-    static defaultProps =
-    {
-        position       : 'top',
-        id             : undefined,
-        isVisible      : true,
-        noWrap         : false,
-        overflowHidden : false,
-        cssMap         : require( './tooltip.css' ),
-        role           : 'default'
-    };
+        const matches = message.match( regexp ) || [];
 
-    render()
-    {
-        const {
-            children,
-            className,
-            cssMap,
-            message,
-            position,
-            id = generateId( 'Tooltip' ),
-            isDismissible,
-            isVisible,
-            noWrap,
-            onClickClose,
-            onMouseOver,
-            onMouseOut,
-            overflowIsHidden,
-            role
-        } = this.props;
-
-        let messageText = message;
-
-        if ( typeof messageText === 'string' )
-        {
-            const regexp = /([^\s].{1,49}(?=\s+|$))|([^\s]{1,50})/g;
-
-            const matches = message.match( regexp ) || [];
-
-            messageText = (
-                <Text className = { cssMap.messageText } noWrap>
-                    { matches.map( line => [ line, <br /> ] ) }
-                </Text> );
-        }
+        messageText = (
+            <Text className = { cssMap.messageText } noWrap>
+                { matches.map( line => [ line, <br /> ] ) }
+            </Text> );
+    }
 
 
-        const tooltip = (
-            <div
-                className = { cssMap.tooltip }
-                role      = "tooltip"
-                id        = { id }>
-                <div className = { cssMap.message }>
-                    { messageText }
-                </div>
-                { isDismissible &&
-                    <div className = { cssMap.iconContainer } >
-                        <IconButton
-                            iconType  = "close"
-                            onClick   = { onClickClose }
-                            iconTheme = "button"
-                            iconSize  = "M" />
-                    </div>
-                }
+    const tooltip = (
+        <div
+            className = { cssMap.tooltip }
+            role      = "tooltip"
+            id        = { id }>
+            <div className = { cssMap.message }>
+                { messageText }
             </div>
+            { isDismissible &&
+                <div className = { cssMap.iconContainer } >
+                    <IconButton
+                        iconType  = "close"
+                        onClick   = { onClickClose }
+                        iconTheme = "button"
+                        iconSize  = "M" />
+                </div>
+            }
+        </div>
+    );
+
+    let contentNode = children;
+
+    if ( typeof children === 'string' )
+    {
+        contentNode = (
+            <Text
+                overflowIsHidden = { overflowIsHidden }
+                noWrap           = { noWrap }>
+                { children }
+            </Text>
         );
+    }
 
-        let contentNode = children;
+    return (
 
-        if ( typeof children === 'string' )
-        {
-            contentNode = (
-                <Text
-                    overflowIsHidden = { overflowIsHidden }
-                    noWrap           = { noWrap }>
-                    { children }
-                </Text>
-            );
-        }
-
-        return (
-
-            <div
-                className    = { buildClassName( className, cssMap, { role, noWrap, position } ) }
-                onMouseEnter = { onMouseOver }
-                onMouseLeave = { onMouseOut }>
-                { contentNode &&
+        <div
+            className = { buildClassName( className, cssMap, {
+                role,
+                noWrap,
+                position,
+            } ) }
+            onMouseEnter = { onMouseOver }
+            onMouseLeave = { onMouseOut }>
+            { contentNode &&
                 <div
                     className        = { cssMap.content }
                     aria-describedby = { isVisible ? id : null }>
                     { contentNode }
                 </div>
-                }
-                { isVisible && tooltip }
-            </div>
+            }
+            { isVisible && tooltip }
+        </div>
 
-        );
-    }
-}
+    );
+};
+
+Tooltip.propTypes =
+{
+    /**
+     *  Node that the Tooltip wraps
+     */
+    children         : PropTypes.node,
+    /**
+     * Extra CSS class name
+     */
+    className        : PropTypes.string,
+    /**
+     *  CSS class map
+     */
+    cssMap           : PropTypes.objectOf( PropTypes.string ),
+    /**
+     * HTML id attribute (overwrite default)
+     */
+    id               : PropTypes.string,
+    /**
+     *  Display the tooltip as user dismissible
+     */
+    isDismissible    : PropTypes.bool,
+    /**
+     *  Display the tooltip
+     */
+    isVisible        : PropTypes.bool,
+    /**
+     *  Tooltip message text (string or JSX)
+     */
+    message          : PropTypes.node,
+    /**
+     *  Text won’t wrap to the next line
+     */
+    noWrap           : PropTypes.bool,
+    /**
+     *  Function to call on “Close” button click: ( e ) => { ... }
+     */
+    onClickClose     : PropTypes.func,
+    /**
+     *  onMouseOver callback function: ( e ) => { ... }
+     */
+    onMouseOver      : PropTypes.func,
+    /**
+     *  onMouseOut callback function: ( e ) => { ... }
+     */
+    onMouseOut       : PropTypes.func,
+    /**
+     *  Hides overflow of wrapped content
+     */
+    overflowIsHidden : PropTypes.bool,
+    /**
+     *  Tooltip position relative to wrapped component
+     */
+    position         : PropTypes.oneOf( [
+        'left',
+        'right',
+        'top',
+        'bottom',
+        'topLeft',
+        'topRight',
+        'bottomLeft',
+        'bottomRight' ] ),
+    /**
+     *  Tooltip role/style
+     */
+    role : PropTypes.oneOf( [
+        'default',
+        'critical',
+        'promoted',
+        'warning',
+    ] ),
+};
+
+Tooltip.defaultProps =
+{
+    children         : undefined,
+    className        : undefined,
+    cssMap           : styles,
+    id               : undefined,
+    isDismissible    : undefined,
+    isVisible        : true,
+    message          : undefined,
+    noWrap           : false,
+    onClickClose     : undefined,
+    onMouseOut       : undefined,
+    onMouseOver      : undefined,
+    overflowIsHidden : false,
+    position         : 'top',
+    role             : 'default',
+};
+
+export default Tooltip;

--- a/src/Uploader/index.jsx
+++ b/src/Uploader/index.jsx
@@ -1,257 +1,273 @@
-import React                            from 'react';
-import PropTypes                        from 'prop-types';
+import React                          from 'react';
+import PropTypes                      from 'prop-types';
+
+import { generateId, buildClassName } from '../utils';
+import Button                         from '../Button';
+import IconWithTooltip                from '../IconWithTooltip';
+import Spinner                        from '../Spinner';
+import IconButton                     from '../IconButton';
+import Tooltip                        from '../Tooltip';
+import Label                          from '../Label';
+import styles                         from './uploader.css';
 
 
-import { generateId, buildClassName }   from '../utils';
-import Button                           from '../Button';
-import IconWithTooltip                  from '../IconWithTooltip';
-import Spinner                          from '../Spinner';
-import IconButton                       from '../IconButton';
-import Tooltip                          from '../Tooltip';
-import Label                            from '../Label';
-
-export default class Uploader extends React.PureComponent
+const Uploader = ( {
+    buttonLabel,
+    className,
+    cssMap,
+    errorMessage,
+    errorMessagePosition,
+    hasError,
+    hasWarning,
+    id = generateId( 'Uploader' ),
+    isDisabled,
+    isReadOnly,
+    label,
+    onChange,
+    onClick,
+    onClickSecondary,
+    onMouseOut,
+    onMouseOver,
+    previewIsDisabled,
+    previewTooltipIsVisible,
+    previewTooltipMessage,
+    tooltipIsVisible,
+    uploadState,
+    warningMessage,
+} ) =>
 {
-    static propTypes =
+    const buttonRole = 'default';
+    let hasTooltip = false;
+    let uploaded   = false;
+    let isLoading  = false;
+    let iconType   = 'upload';
+    const iconTheme  = 'button';
+
+    let uploaderButtonClass = cssMap.uploadButton;
+    let messageType;
+    let message;
+
+
+    if ( uploadState === 'uploading' )
     {
-        /**
-        *  Label text
-        */
-        label       : PropTypes.string,
-        /**
-        *  “Upload” Button text
-        */
-        buttonLabel : PropTypes.string,
-        /**
-        *  Uploader state
-        */
-        uploadState : PropTypes.oneOf( [ 'default',
-            'uploading',
-            'uploaded' ] ),
-        /**
-        *  Display as disabled
-        */
-        isDisabled              : PropTypes.bool,
-        /**
-         * HTML id attribute (overwrite default)
-         */
-        id                      : PropTypes.string,
-        /**
-        *  Display as read-only
-        */
-        isReadOnly              : PropTypes.bool,
-        /**
-        *  Display as error/invalid
-        */
-        hasError                : PropTypes.bool,
-        /**
-        *  Tooltip error message text (string or JSX)
-        */
-        errorMessage            : PropTypes.node,
-        /**
-        *  Display as warning ( adds warning icon )
-        */
-        hasWarning              : PropTypes.bool,
-        /**
-        *  Tooltip warning message text (string or JSX)
-        */
-        warningMessage          : PropTypes.node,
-        /**
-         * Error or warning tooltip is visible
-         */
-        tooltipIsVisible        : PropTypes.bool,
-        /**
-         * Preview tootltip messsage text (string or JSX)
-         */
-        previewTooltipMessage   : PropTypes.node,
-        /**
-         * Preview tootltip is visible
-         */
-        previewTooltipIsVisible : PropTypes.bool,
-        /**
-         * Preview button is disabled
-         */
-        previewIsDisabled       : PropTypes.bool,
-        /**
-         * onClick callback function: ( e ) => { ... }
-         */
-        onClick                 : PropTypes.func,
-        /**
-         * onClickSecondary callback function: ( e ) => { ... }
-         */
-        onClickSecondary        : PropTypes.func,
-        /**
-         * onChange callback function: ( e ) => { ... }
-         */
-        onChange                : PropTypes.func,
-        /**
-         * onMouseOut callback function: ( e ) => { ... }
-         */
-        onMouseOut              : PropTypes.func,
-        /**
-         * onMouseOver callback function: ( e ) => { ... }
-         */
-        onMouseOver             : PropTypes.func,
-        /**
-        *  Error message position relative to the icon
-        */
-        errorMessagePosition    : PropTypes.oneOf( [ 'left',
-            'right',
-            'top',
-            'bottom',
-            'topLeft',
-            'topRight' ] )
-    };
-
-    static defaultProps =
+        isLoading  = true;
+        iconType   = 'none';
+        uploaderButtonClass = cssMap.uploaderButton;
+    }
+    else if ( uploadState === 'uploaded' )
     {
-        uploadState             : 'default',
-        hasError                : false,
-        hasWarning              : false,
-        tooltipIsVisible        : false,
-        errorMessagePosition    : 'top',
-        id                      : undefined,
-        isDisabled              : false,
-        isReadOnly              : false,
-        previewTooltipIsVisible : false,
-        buttonLabel             : 'Upload',
-        cssMap                  : require( './uploader.css' )
-    };
+        uploaded   = true;
+        iconType   = 'none';
+        isLoading  = false;
+        uploaderButtonClass = cssMap.uploaderButton;
+    }
 
-    render()
+
+    if ( hasWarning )
     {
-        const {
-            buttonLabel,
-            className,
-            cssMap,
-            errorMessage,
-            hasError,
-            hasWarning,
-            id = generateId( 'Uploader' ),
-            isDisabled,
-            isReadOnly,
-            label,
-            onChange,
-            onClick,
-            onClickSecondary,
-            onMouseOut,
-            onMouseOver,
-            previewIsDisabled,
-            previewTooltipIsVisible,
-            previewTooltipMessage,
-            tooltipIsVisible,
-            errorMessagePosition,
-            uploadState,
-            warningMessage
-        } = this.props;
-
-        const buttonRole = 'default';
-        let hasTooltip = false;
-        let uploaded   = false;
-        let isLoading  = false;
-        let iconType   = 'upload';
-        const iconTheme  = 'button';
-
-        let uploaderButtonClass = cssMap.uploadButton;
-        let messageType;
-        let message;
+        hasTooltip  = true;
+        messageType = 'alert';
+        message     = warningMessage;
+    }
+    if ( hasError )
+    {
+        hasTooltip  = true;
+        messageType = 'error';
+        message     = errorMessage;
+    }
 
 
-        if ( uploadState === 'uploading' )
-        {
-            isLoading  = true;
-            iconType   = 'none';
-            uploaderButtonClass = cssMap.uploaderButton;
-        }
-        else if ( uploadState === 'uploaded' )
-        {
-            uploaded   = true;
-            iconType   = 'none';
-            isLoading  = false;
-            uploaderButtonClass = cssMap.uploaderButton;
-        }
+    return (
 
-
-        if ( hasWarning )
-        {
-            hasTooltip  = true;
-            messageType = 'alert';
-            message     = warningMessage;
-        }
-        if ( hasError )
-        {
-            hasTooltip  = true;
-            messageType = 'error';
-            message     = errorMessage;
-        }
-
-
-        return (
-
-            <div
-                className    = { buildClassName( className, cssMap, {
-                    loading         : isLoading,
-                    uploaded,
-                    disabled        : isDisabled,
-                    previewDisabled : previewIsDisabled
-                } ) }
-                onMouseEnter = { onMouseOver }
-                onMouseLeave = { onMouseOut } >
-                <input
-                    type         = "file"
-                    name         = { `${id}-file` }
-                    className    = { cssMap.input }
-                    onChange     = { onChange } />
-                { label &&
-                <Label
-                    overflowIsHidden
-                    htmlFor    = { `${id}-file` }
-                    isDisabled = { isDisabled }>
-                    { label }
-                </Label>
-                }
-                <IconWithTooltip
-                    className        = { cssMap.iconWithTooltip }
-                    iconType         = { messageType }
-                    iconPosition     = "topRight"
-                    message          = { message }
-                    iconIsVisible    = { hasTooltip }
-                    tooltipPosition  = { errorMessagePosition }
-                    tooltipIsVisible = { tooltipIsVisible }>
-                    <div className = { cssMap.buttonsContainer }>
-                        <Tooltip
-                            isVisible = { uploadState ===
-                                'uploaded' && previewTooltipIsVisible }
-                            message   = { previewTooltipMessage }
-                            className = { cssMap.previewTooltip }>
-                            <Button
-                                role       = { buttonRole }
-                                className  = { uploaderButtonClass }
-                                onClick    = { onClick }
-                                isDisabled = { isDisabled }
-                                isReadOnly = { isReadOnly }
-                                iconType   = { iconType }>
-                                { buttonLabel }
-                            </Button>
-                        </Tooltip>
-                        { isLoading &&
-                        <div className = { cssMap.loadingOverlay }>
-                            <Spinner className = { cssMap.spinner } />
-                        </div>
-                        }
-                        { uploaded  &&
-                        <IconButton
-                            className  = { cssMap.uploadedButton }
-                            onClick    = { onClickSecondary }
+        <div
+            className    = { buildClassName( className, cssMap, {
+                loading         : isLoading,
+                uploaded,
+                disabled        : isDisabled,
+                previewDisabled : previewIsDisabled,
+            } ) }
+            onMouseEnter = { onMouseOver }
+            onMouseLeave = { onMouseOut } >
+            <input
+                type         = "file"
+                name         = { `${id}-file` }
+                className    = { cssMap.input }
+                onChange     = { onChange } />
+            { label &&
+            <Label
+                overflowIsHidden
+                htmlFor    = { `${id}-file` }
+                isDisabled = { isDisabled }>
+                { label }
+            </Label>
+            }
+            <IconWithTooltip
+                className        = { cssMap.iconWithTooltip }
+                iconType         = { messageType }
+                iconPosition     = "topRight"
+                message          = { message }
+                iconIsVisible    = { hasTooltip }
+                tooltipPosition  = { errorMessagePosition }
+                tooltipIsVisible = { tooltipIsVisible }>
+                <div className = { cssMap.buttonsContainer }>
+                    <Tooltip
+                        isVisible = { uploadState ===
+                            'uploaded' && previewTooltipIsVisible }
+                        message   = { previewTooltipMessage }
+                        className = { cssMap.previewTooltip }>
+                        <Button
+                            role       = { buttonRole }
+                            className  = { uploaderButtonClass }
+                            onClick    = { onClick }
                             isDisabled = { isDisabled }
                             isReadOnly = { isReadOnly }
-                            iconType   = "delete"
-                            iconTheme  = { iconTheme } />
-                        }
+                            iconType   = { iconType }>
+                            { buttonLabel }
+                        </Button>
+                    </Tooltip>
+                    { isLoading &&
+                    <div className = { cssMap.loadingOverlay }>
+                        <Spinner className = { cssMap.spinner } />
                     </div>
-                </IconWithTooltip>
-            </div>
+                    }
+                    { uploaded  &&
+                    <IconButton
+                        className  = { cssMap.uploadedButton }
+                        onClick    = { onClickSecondary }
+                        isDisabled = { isDisabled }
+                        isReadOnly = { isReadOnly }
+                        iconType   = "delete"
+                        iconTheme  = { iconTheme } />
+                    }
+                </div>
+            </IconWithTooltip>
+        </div>
 
-        );
-    }
-}
+    );
+};
+
+Uploader.propTypes =
+{
+    /**
+     *  CSS class map
+     */
+    cssMap      : PropTypes.objectOf( PropTypes.string ),
+    /**
+    *  Label text
+    */
+    label       : PropTypes.string,
+    /**
+    *  “Upload” Button text
+    */
+    buttonLabel : PropTypes.string,
+    /**
+    *  Uploader state
+    */
+    uploadState : PropTypes.oneOf( [
+        'default',
+        'uploading',
+        'uploaded',
+    ] ),
+    /**
+    *  Display as disabled
+    */
+    isDisabled              : PropTypes.bool,
+    /**
+     * HTML id attribute (overwrite default)
+     */
+    id                      : PropTypes.string,
+    /**
+    *  Display as read-only
+    */
+    isReadOnly              : PropTypes.bool,
+    /**
+    *  Display as error/invalid
+    */
+    hasError                : PropTypes.bool,
+    /**
+    *  Tooltip error message text (string or JSX)
+    */
+    errorMessage            : PropTypes.node,
+    /**
+    *  Display as warning ( adds warning icon )
+    */
+    hasWarning              : PropTypes.bool,
+    /**
+    *  Tooltip warning message text (string or JSX)
+    */
+    warningMessage          : PropTypes.node,
+    /**
+     * Error or warning tooltip is visible
+     */
+    tooltipIsVisible        : PropTypes.bool,
+    /**
+     * Preview tootltip messsage text (string or JSX)
+     */
+    previewTooltipMessage   : PropTypes.node,
+    /**
+     * Preview tootltip is visible
+     */
+    previewTooltipIsVisible : PropTypes.bool,
+    /**
+     * Preview button is disabled
+     */
+    previewIsDisabled       : PropTypes.bool,
+    /**
+     * onClick callback function: ( e ) => { ... }
+     */
+    onClick                 : PropTypes.func,
+    /**
+     * onClickSecondary callback function: ( e ) => { ... }
+     */
+    onClickSecondary        : PropTypes.func,
+    /**
+     * onChange callback function: ( e ) => { ... }
+     */
+    onChange                : PropTypes.func,
+    /**
+     * onMouseOut callback function: ( e ) => { ... }
+     */
+    onMouseOut              : PropTypes.func,
+    /**
+     * onMouseOver callback function: ( e ) => { ... }
+     */
+    onMouseOver             : PropTypes.func,
+    /**
+    *  Error message position relative to the icon
+    */
+    errorMessagePosition    : PropTypes.oneOf( [
+        'left',
+        'right',
+        'top',
+        'bottom',
+        'topLeft',
+        'topRight',
+    ] ),
+};
+
+Uploader.defaultProps =
+{
+    buttonLabel             : 'Upload',
+    cssMap                  : styles,
+    errorMessage            : undefined,
+    errorMessagePosition    : 'top',
+    hasError                : false,
+    hasWarning              : false,
+    id                      : undefined,
+    isDisabled              : false,
+    isReadOnly              : false,
+    label                   : undefined,
+    onChange                : undefined,
+    onClick                 : undefined,
+    onClickSecondary        : undefined,
+    onMouseOut              : undefined,
+    onMouseOver             : undefined,
+    previewIsDisabled       : undefined,
+    previewTooltipIsVisible : false,
+    previewTooltipMessage   : undefined,
+    tooltipIsVisible        : false,
+    uploadState             : 'default',
+    warningMessage          : undefined,
+};
+
+export default Uploader;


### PR DESCRIPTION
- We shouldn’t ever use `React.PureComponent` as any `shouldComponentUpdate` optimizations can be handled in a wrapper or higher-order component
- Turns out all the components that are currently using `React.PureComponent` can easily be converted to functions anyways