### PR TITLE
[Table] Added style for borders:none

### DIFF
--- a/src/Table/index.jsx
+++ b/src/Table/index.jsx
@@ -142,7 +142,7 @@ Table.propTypes =
     /**
      *  Body Text style configuration
      */
-    bodyTextProps : PropTypes.shape,
+    bodyTextProps : PropTypes.object,
     /**
      *  Display table with borders
      */
@@ -171,7 +171,7 @@ Table.propTypes =
     /**
      *  Header Text style configuration
      */
-    headerTextProps : PropTypes.shape,
+    headerTextProps : PropTypes.object,
     /**
      *  Display as zebra-striped
      */

--- a/src/Table/index.jsx
+++ b/src/Table/index.jsx
@@ -55,7 +55,12 @@ const Table = ( {
                 const column      = columns[ j ];
                 const columnProps = column && {
                     align     : cell.props.align || column.align,
-                    textProps : { ...bodyTextProps, ...column.textProps, ...( rows[ i ] && rows[ i ].textProps ), ...cell.props.textProps },
+                    textProps : {
+                        ...bodyTextProps,
+                        ...column.textProps,
+                        ...( rows[ i ] && rows[ i ].textProps ),
+                        ...cell.props.textProps,
+                    },
                     columnTitle : cell.props.columnTitle || column.title,
                     size        : cell.props.size || column.size,
                     isRowHeader : cell.props.isRowHeader ||
@@ -137,7 +142,7 @@ Table.propTypes =
     /**
      *  Body Text style configuration
      */
-    bodyTextProps : PropTypes.object,
+    bodyTextProps : PropTypes.shape,
     /**
      *  Display table with borders
      */
@@ -166,7 +171,7 @@ Table.propTypes =
     /**
      *  Header Text style configuration
      */
-    headerTextProps : PropTypes.object,
+    headerTextProps : PropTypes.shape,
     /**
      *  Display as zebra-striped
      */
@@ -196,11 +201,12 @@ Table.propTypes =
     /**
      * 2D Array of table values (for convenience)
      */
-    values          : PropTypes.arrayOf( PropTypes.arrayOf( PropTypes.string ) ),
+    values          : PropTypes.arrayOf( PropTypes
+        .arrayOf( PropTypes.string ) ),
     /**
      *  Vertical alignment inside cells
      */
-    verticalAlign   : PropTypes.oneOf( [ 'top', 'bottom', 'middle' ] ),
+    verticalAlign : PropTypes.oneOf( [ 'top', 'bottom', 'middle' ] ),
 };
 
 Table.defaultProps =

--- a/src/Table/table.css
+++ b/src/Table/table.css
@@ -20,6 +20,7 @@
     }
 }
 
+.borders__none,
 .borders__rows,
 .borders__cells,
 .borders__rowDivider,
@@ -38,6 +39,15 @@
     {
         margin:     0;
         background: var( --PC-WHITE );
+    }
+}
+
+.borders__none
+{
+    .row,
+    .cell
+    {
+        border: none;
     }
 }
 


### PR DESCRIPTION
For #578:

- added class for `borders: none` in case when more `Table` components are nested to avoid style overriding
- minor linter fixes in `index.js`