### PR TITLE
Force new stacking context for ScrollBox content #614

### DIFF
--- a/src/ScrollBox/scrollBox.css
+++ b/src/ScrollBox/scrollBox.css
@@ -20,6 +20,10 @@
 
     .inner
     {
+        /* creates stacking context */
+        position:   relative;
+        z-index:    0;
+
         width:      100%;
         height:     100%;
         overflow:   scroll;


### PR DESCRIPTION
Closes #614:
- Forces new CSS stacking context for ScrollBox content

Browser check:
- [x] Chrome
- [x] FF
- [x] IE10
- [x] Edge (current -1)
- [x] Safari (current -2)