### PR TITLE
Remove TableCell header text capitalization #619

### DIFF
--- a/src/TableCell/index.jsx
+++ b/src/TableCell/index.jsx
@@ -34,10 +34,9 @@ const TableCell = ( {
 
     if ( isHeader || isRowHeader )
     {
-        headerStyle.allCaps = true;
         headerStyle.color = '#4b627d';
         headerStyle.letterSpacing = '0.5';
-        headerStyle.size = 'S';
+        headerStyle.size = 'M';
         headerStyle.variant = 'SemiBold';
     }
 

--- a/src/TableCell/tableCell.css
+++ b/src/TableCell/tableCell.css
@@ -25,7 +25,6 @@ $shark: 768px;
     font-size:          var( --typo-2 );
     line-height:        var( --line-height-m );
     letter-spacing:     0.5px;
-    text-transform:     uppercase;
     text-decoration:    none;
     color:              var( --PC-GREY--D25 );
     cursor:             text;


### PR DESCRIPTION
Closes #619:
- Remove the `text-transform: capitalize` from Table header cells