### PR TITLE
change display from flex to block #673

### DIFF
--- a/src/DatePicker/datePickerItem.css
+++ b/src/DatePicker/datePickerItem.css
@@ -11,11 +11,7 @@
 
 .default
 {
-    display:            flex;
-
-    flex-direction:     row;
-    align-items:        center;
-    justify-content:    center;
+    display:            block;
 
     padding:            0;
     border:             1px solid transparent;


### PR DESCRIPTION
#673 switched `flex` value of DatePickerItem to `block` as `<button>` handles the centring for x and y axis by default.

Tested in: chrome, FF, Safari, Edge and IE 10.