### PR TITLE
Updated driver error messages

### DIFF
--- a/src/Button/driver.js
+++ b/src/Button/driver.js
@@ -18,14 +18,14 @@ export default class ButtonDriver
     constructor( wrapper )
     {
         this.wrapper = wrapper;
-        this.button  = wrapper
-            .find( `.${this.wrapper.props().cssMap.default}` ).first();
+        this.cssMap  = wrapper.props().cssMap;
+        this.button  = wrapper.find( `.${this.cssMap.default}` ).first();
     }
 
     click()
     {
         const props = this.wrapper.props();
-        const { label } = props;
+        const label = this.wrapper.find( `.${this.cssMap.label}` ).text();
 
         if ( props.isDisabled )
         {
@@ -49,7 +49,7 @@ export default class ButtonDriver
     mouseOver()
     {
         const props = this.wrapper.props();
-        const { label } = props;
+        const label = this.wrapper.find( `.${this.cssMap.label}` ).text();
 
         if ( props.isDisabled )
         {
@@ -68,7 +68,7 @@ export default class ButtonDriver
     mouseOut()
     {
         const props = this.wrapper.props();
-        const { label } = props;
+        const label = this.wrapper.find( `.${this.cssMap.label}` ).text();
 
         if ( props.isDisabled )
         {
@@ -87,7 +87,7 @@ export default class ButtonDriver
     focus()
     {
         const props = this.wrapper.props();
-        const { label } = props;
+        const label = this.wrapper.find( `.${this.cssMap.label}` ).text();
 
         if ( props.isDisabled )
         {
@@ -111,7 +111,7 @@ export default class ButtonDriver
     blur()
     {
         const props = this.wrapper.props();
-        const { label } = props;
+        const label = this.wrapper.find( `.${this.cssMap.label}` ).text();
 
         if ( props.isDisabled )
         {

--- a/src/CheckableGroup/driver.js
+++ b/src/CheckableGroup/driver.js
@@ -11,8 +11,8 @@ import { Checkbox, Radio } from '../index';
 
 
 const ERR = {
-    CHECKABLEGROUP_ERR : ( label, event, state ) => `CheckableGroup \
-'${label}' cannot simulate ${event} since it is ${state}`,
+    CHECKABLEGROUP_ERR : ( event, state ) => `CheckableGroup cannot simulate \
+${event} since it is ${state}`,
 };
 
 
@@ -21,7 +21,6 @@ export default class CheckableGroupDriver
     constructor( wrapper )
     {
         this.wrapper    = wrapper;
-        this.cssMap     = wrapper.props().cssMap;
         this.checkables = wrapper.find( Checkbox ).length ?
             wrapper.find( Checkbox ) :
             wrapper.find( Radio );
@@ -29,19 +28,18 @@ export default class CheckableGroupDriver
 
     change( index = 0 )
     {
-        const props     = this.wrapper.props();
-        const { label } = props;
+        const props = this.wrapper.props();
 
         if ( props.isDisabled )
         {
             throw new Error( ERR
-                .CHECKABLEGROUP_ERR( label, 'change', 'disabled' ) );
+                .CHECKABLEGROUP_ERR( 'change', 'disabled' ) );
         }
 
         if ( props.isReadOnly )
         {
             throw new Error( ERR
-                .CHECKABLEGROUP_ERR( label, 'change', 'read only' ) );
+                .CHECKABLEGROUP_ERR( 'change', 'read only' ) );
         }
 
 

--- a/src/CheckableGroup/driver.js
+++ b/src/CheckableGroup/driver.js
@@ -29,8 +29,8 @@ export default class CheckableGroupDriver
 
     change( index = 0 )
     {
-        const props = this.wrapper.props();
-        const label = this.wrapper.find( `.${props.cssMap.list}` ).text();
+        const props     = this.wrapper.props();
+        const { label } = props;
 
         if ( props.isDisabled )
         {

--- a/src/CheckableGroup/driver.js
+++ b/src/CheckableGroup/driver.js
@@ -29,8 +29,8 @@ export default class CheckableGroupDriver
 
     change( index = 0 )
     {
-        const props     = this.wrapper.props();
-        const { label } = props;
+        const props = this.wrapper.props();
+        const label = this.wrapper.find( `.${props.cssMap.list}` ).text();
 
         if ( props.isDisabled )
         {

--- a/src/CheckableGroup/tests.jsx
+++ b/src/CheckableGroup/tests.jsx
@@ -54,8 +54,8 @@ describe( 'CheckableGroupDriver', () =>
             {
                 wrapper.setProps( { isDisabled: true, label: 'Tekeli-li' } );
 
-                const expectedError = 'CheckableGroup \'Tekeli-li\' cannot \
-simulate change since it is disabled';
+                const expectedError = 'CheckableGroup cannot simulate change \
+since it is disabled';
 
                 expect( () => driver.change() ).toThrow( expectedError );
             } );
@@ -87,8 +87,8 @@ simulate change since it is disabled';
             {
                 wrapper.setProps( { isReadOnly: true, label: 'Tekeli-li' } );
 
-                const expectedError = 'CheckableGroup \'Tekeli-li\' cannot \
-simulate change since it is read only';
+                const expectedError = 'CheckableGroup cannot simulate change \
+since it is read only';
 
                 expect( () => driver.change() ).toThrow( expectedError );
             } );

--- a/src/CheckableGroup/tests.jsx
+++ b/src/CheckableGroup/tests.jsx
@@ -86,6 +86,7 @@ simulate change since it is disabled';
             test( 'throws the expected error when isReadOnly', () =>
             {
                 wrapper.setProps( { isReadOnly: true, label: 'Tekeli-li' } );
+                console.log( wrapper.debug() );
 
                 const expectedError = 'CheckableGroup \'Tekeli-li\' cannot \
 simulate change since it is read only';

--- a/src/CheckableGroup/tests.jsx
+++ b/src/CheckableGroup/tests.jsx
@@ -86,7 +86,6 @@ simulate change since it is disabled';
             test( 'throws the expected error when isReadOnly', () =>
             {
                 wrapper.setProps( { isReadOnly: true, label: 'Tekeli-li' } );
-                console.log( wrapper.debug() );
 
                 const expectedError = 'CheckableGroup \'Tekeli-li\' cannot \
 simulate change since it is read only';

--- a/src/Checkbox/driver.js
+++ b/src/Checkbox/driver.js
@@ -23,8 +23,9 @@ export default class CheckboxDriver
 
     blur()
     {
-        const props     = this.wrapper.props();
-        const { label } = props;
+        const props = this.wrapper.props();
+        const label = this.wrapper.find( `.${props.cssMap.labelContent}` )
+            .text();
 
         if ( props.isDisabled )
         {
@@ -42,8 +43,9 @@ export default class CheckboxDriver
 
     focus()
     {
-        const props     = this.wrapper.props();
-        const { label } = props;
+        const props = this.wrapper.props();
+        const label = this.wrapper.find( `.${props.cssMap.labelContent}` )
+            .text();
 
         if ( props.isDisabled )
         {
@@ -61,9 +63,10 @@ export default class CheckboxDriver
 
     change()
     {
-        const props     = this.wrapper.props();
-        const { label } = props;
-        const node      = this.control.getNode();
+        const props = this.wrapper.props();
+        const label = this.wrapper.find( `.${props.cssMap.labelContent}` )
+            .text();
+        const node   = this.control.getNode();
 
         if ( props.isDisabled )
         {
@@ -82,8 +85,9 @@ export default class CheckboxDriver
 
     click()
     {
-        const props     = this.wrapper.props();
-        const { label } = props;
+        const props = this.wrapper.props();
+        const label = this.wrapper.find( `.${props.cssMap.labelContent}` )
+            .text();
 
         if ( props.isDisabled )
         {
@@ -101,8 +105,9 @@ export default class CheckboxDriver
 
     mouseOver()
     {
-        const props     = this.wrapper.props();
-        const { label } = props;
+        const props = this.wrapper.props();
+        const label = this.wrapper.find( `.${props.cssMap.labelContent}` )
+            .text();
 
         if ( props.isDisabled )
         {
@@ -116,8 +121,9 @@ export default class CheckboxDriver
 
     mouseOut()
     {
-        const props     = this.wrapper.props();
-        const { label } = props;
+        const props = this.wrapper.props();
+        const label = this.wrapper.find( `.${props.cssMap.labelContent}` )
+            .text();
 
         if ( props.isDisabled )
         {

--- a/src/Checkbox/driver.js
+++ b/src/Checkbox/driver.js
@@ -17,8 +17,7 @@ export default class CheckboxDriver
     constructor( wrapper )
     {
         this.wrapper = wrapper;
-        this.control = wrapper
-            .find( `.${this.wrapper.props().cssMap.input}` );
+        this.control = wrapper.find( `.${this.wrapper.props().cssMap.input}` );
     }
 
     blur()
@@ -80,6 +79,7 @@ export default class CheckboxDriver
 
         node.checked = !node.checked;
         this.control.simulate( 'change' );
+
         return this;
     }
 

--- a/src/CheckboxGroup/driver.js
+++ b/src/CheckboxGroup/driver.js
@@ -1,3 +1,12 @@
+/*
+ * Copyright (c) 2018 dunnhumby Germany GmbH.
+ * All rights reserved.
+ *
+ * This source code is licensed under the MIT license found in the LICENSE file
+ * in the root directory of this source tree.
+ *
+ */
+
 import { CheckableGroup } from '../index';
 
 export default class CheckboxGroupDriver

--- a/src/CheckboxGroup/driver.js
+++ b/src/CheckboxGroup/driver.js
@@ -5,7 +5,6 @@ export default class CheckboxGroupDriver
     constructor( wrapper )
     {
         this.wrapper    = wrapper;
-        this.cssMap     = wrapper.props().cssMap;
         this.checkables = wrapper.find( CheckableGroup );
     }
 

--- a/src/CodeEditor/driver.js
+++ b/src/CodeEditor/driver.js
@@ -31,7 +31,7 @@ export default class CodeEditorDriver
 
     focus()
     {
-        const props     = this.wrapper.props();
+        const props = this.wrapper.props();
 
         if ( props.isDisabled )
         {
@@ -50,7 +50,7 @@ export default class CodeEditorDriver
 
     blur()
     {
-        const props     = this.wrapper.props();
+        const props = this.wrapper.props();
 
         if ( props.isDisabled )
         {
@@ -73,7 +73,7 @@ export default class CodeEditorDriver
 
     change( val )
     {
-        const props     = this.wrapper.props();
+        const props = this.wrapper.props();
 
         if ( props.isDisabled )
         {
@@ -94,7 +94,7 @@ export default class CodeEditorDriver
 
     mouseOver()
     {
-        const props     = this.wrapper.props();
+        const props = this.wrapper.props();
 
         if ( props.isDisabled )
         {
@@ -114,7 +114,7 @@ export default class CodeEditorDriver
 
     mouseOut()
     {
-        const props     = this.wrapper.props();
+        const props = this.wrapper.props();
 
         if ( props.isDisabled )
         {

--- a/src/CodeEditor/driver.js
+++ b/src/CodeEditor/driver.js
@@ -89,6 +89,7 @@ export default class CodeEditorDriver
 
         this.control.setValue( val );
         this.wrapper.prop( 'onChange' )( this.control.getValue() );
+
         return this;
     }
 

--- a/src/CodeEditor/driver.js
+++ b/src/CodeEditor/driver.js
@@ -9,8 +9,8 @@
 
 /* global document */
 const ERR = {
-    CODEEDITOR_ERR : ( label, event, state ) =>
-        `CodeEditor '${label}' cannot simulate ${event} since it is ${state}`,
+    CODEEDITOR_ERR : ( event, state ) =>
+        `CodeEditor cannot simulate ${event} since it is ${state}`,
 };
 
 export default class CodeEditorDriver
@@ -33,17 +33,16 @@ export default class CodeEditorDriver
     focus()
     {
         const props     = this.wrapper.props();
-        const { label } = props;
 
         if ( props.isDisabled )
         {
-            throw new Error( ERR.CODEEDITOR_ERR( label, 'focus', 'disabled' ) );
+            throw new Error( ERR.CODEEDITOR_ERR( 'focus', 'disabled' ) );
         }
 
         if ( props.isReadOnly )
         {
             throw new Error( ERR
-                .CODEEDITOR_ERR( label, 'focus', 'read only' ) );
+                .CODEEDITOR_ERR( 'focus', 'read only' ) );
         }
 
         this.control.focus();
@@ -53,16 +52,15 @@ export default class CodeEditorDriver
     blur()
     {
         const props     = this.wrapper.props();
-        const { label } = props;
 
         if ( props.isDisabled )
         {
-            throw new Error( ERR.CODEEDITOR_ERR( label, 'blur', 'disabled' ) );
+            throw new Error( ERR.CODEEDITOR_ERR( 'blur', 'disabled' ) );
         }
 
         if ( props.isReadOnly )
         {
-            throw new Error( ERR.CODEEDITOR_ERR( label, 'blur', 'read only' ) );
+            throw new Error( ERR.CODEEDITOR_ERR( 'blur', 'read only' ) );
         }
 
         if ( this.control.hasFocus() && Boolean( document ) &&
@@ -77,18 +75,17 @@ export default class CodeEditorDriver
     change( val )
     {
         const props     = this.wrapper.props();
-        const { label } = props;
 
         if ( props.isDisabled )
         {
             throw new Error( ERR
-                .CODEEDITOR_ERR( label, 'change', 'disabled' ) );
+                .CODEEDITOR_ERR( 'change', 'disabled' ) );
         }
 
         if ( props.isReadOnly )
         {
             throw new Error( ERR
-                .CODEEDITOR_ERR( label, 'change', 'read only' ) );
+                .CODEEDITOR_ERR( 'change', 'read only' ) );
         }
 
         this.control.setValue( val );
@@ -99,18 +96,17 @@ export default class CodeEditorDriver
     mouseOver()
     {
         const props     = this.wrapper.props();
-        const { label } = props;
 
         if ( props.isDisabled )
         {
             throw new Error( ERR
-                .CODEEDITOR_ERR( label, 'mouseOver', 'disabled' ) );
+                .CODEEDITOR_ERR( 'mouseOver', 'disabled' ) );
         }
 
         if ( props.isReadOnly )
         {
             throw new Error( ERR
-                .CODEEDITOR_ERR( label, 'mouseOver', 'read only' ) );
+                .CODEEDITOR_ERR( 'mouseOver', 'read only' ) );
         }
 
         this.wrapper.simulate( 'mouseenter' );
@@ -120,18 +116,17 @@ export default class CodeEditorDriver
     mouseOut()
     {
         const props     = this.wrapper.props();
-        const { label } = props;
 
         if ( props.isDisabled )
         {
             throw new Error( ERR
-                .CODEEDITOR_ERR( label, 'mouseOut', 'disabled' ) );
+                .CODEEDITOR_ERR( 'mouseOut', 'disabled' ) );
         }
 
         if ( props.isReadOnly )
         {
             throw new Error( ERR
-                .CODEEDITOR_ERR( label, 'mouseOut', 'read only' ) );
+                .CODEEDITOR_ERR( 'mouseOut', 'read only' ) );
         }
 
         this.wrapper.simulate( 'mouseleave' );

--- a/src/CodeEditor/tests.jsx
+++ b/src/CodeEditor/tests.jsx
@@ -74,7 +74,7 @@ describe( 'CodeEditorDriver', () =>
         {
             test( 'throws the expected error when isDisabled', () =>
             {
-                wrapper.setProps( { isDisabled: true, label: 'Tekeli-li' } );
+                wrapper.setProps( { isDisabled: true } );
 
                 const expectedError = 'CodeEditor cannot simulate blur since \
 it is disabled';
@@ -107,7 +107,7 @@ it is disabled';
         {
             test( 'throws the expected error when isReadOnly', () =>
             {
-                wrapper.setProps( { isReadOnly: true, label: 'Tekeli-li' } );
+                wrapper.setProps( { isReadOnly: true } );
 
                 const expectedError = 'CodeEditor cannot simulate blur since \
 it is read only';
@@ -154,7 +154,7 @@ it is read only';
         {
             test( 'throws the expected error when isDisabled', () =>
             {
-                wrapper.setProps( { isDisabled: true, label: 'Tekeli-li' } );
+                wrapper.setProps( { isDisabled: true } );
 
                 const expectedError = 'CodeEditor cannot simulate focus since \
 it is disabled';
@@ -187,7 +187,7 @@ it is disabled';
         {
             test( 'throws the expected error when isReadOnly', () =>
             {
-                wrapper.setProps( { isReadOnly: true, label: 'Tekeli-li' } );
+                wrapper.setProps( { isReadOnly: true } );
 
                 const expectedError = 'CodeEditor cannot simulate focus since \
 it is read only';
@@ -234,7 +234,7 @@ it is read only';
         {
             test( 'throws the expected error when isDisabled', () =>
             {
-                wrapper.setProps( { isDisabled: true, label: 'Tekeli-li' } );
+                wrapper.setProps( { isDisabled: true } );
 
                 const expectedError = 'CodeEditor cannot simulate change since \
 it is disabled';
@@ -268,7 +268,7 @@ it is disabled';
         {
             test( 'throws the expected error when isReadOnly', () =>
             {
-                wrapper.setProps( { isReadOnly: true, label: 'Tekeli-li' } );
+                wrapper.setProps( { isReadOnly: true } );
 
                 const expectedError = 'CodeEditor cannot simulate change since \
 it is read only';
@@ -317,7 +317,7 @@ it is read only';
             {
                 const expectedError = 'CodeEditor cannot simulate mouseOut \
 since it is disabled';
-                wrapper.setProps( { isDisabled: true, label: 'Tekeli-li' } );
+                wrapper.setProps( { isDisabled: true } );
 
                 expect( () => driver.mouseOut() ).toThrow( expectedError );
             } );
@@ -362,7 +362,7 @@ since it is disabled';
             {
                 const expectedError = 'CodeEditor cannot simulate mouseOut \
 since it is disabled';
-                wrapper.setProps( { isDisabled: true, label: 'Tekeli-li' } );
+                wrapper.setProps( { isDisabled: true } );
 
                 expect( () => driver.mouseOut() ).toThrow( expectedError );
             } );

--- a/src/CodeEditor/tests.jsx
+++ b/src/CodeEditor/tests.jsx
@@ -76,8 +76,8 @@ describe( 'CodeEditorDriver', () =>
             {
                 wrapper.setProps( { isDisabled: true, label: 'Tekeli-li' } );
 
-                const expectedError = 'CodeEditor \'Tekeli-li\' cannot \
-simulate blur since it is disabled';
+                const expectedError = 'CodeEditor cannot simulate blur since \
+it is disabled';
 
                 expect( () => driver.blur() ).toThrow( expectedError );
             } );
@@ -109,8 +109,8 @@ simulate blur since it is disabled';
             {
                 wrapper.setProps( { isReadOnly: true, label: 'Tekeli-li' } );
 
-                const expectedError = 'CodeEditor \'Tekeli-li\' cannot \
-simulate blur since it is read only';
+                const expectedError = 'CodeEditor cannot simulate blur since \
+it is read only';
 
                 expect( () => driver.blur() ).toThrow( expectedError );
             } );
@@ -156,8 +156,8 @@ simulate blur since it is read only';
             {
                 wrapper.setProps( { isDisabled: true, label: 'Tekeli-li' } );
 
-                const expectedError = 'CodeEditor \'Tekeli-li\' cannot \
-simulate focus since it is disabled';
+                const expectedError = 'CodeEditor cannot simulate focus since \
+it is disabled';
 
                 expect( () => driver.focus() ).toThrow( expectedError );
             } );
@@ -189,8 +189,8 @@ simulate focus since it is disabled';
             {
                 wrapper.setProps( { isReadOnly: true, label: 'Tekeli-li' } );
 
-                const expectedError = 'CodeEditor \'Tekeli-li\' cannot \
-simulate focus since it is read only';
+                const expectedError = 'CodeEditor cannot simulate focus since \
+it is read only';
 
                 expect( () => driver.focus() ).toThrow( expectedError );
             } );
@@ -236,8 +236,8 @@ simulate focus since it is read only';
             {
                 wrapper.setProps( { isDisabled: true, label: 'Tekeli-li' } );
 
-                const expectedError = 'CodeEditor \'Tekeli-li\' cannot \
-simulate change since it is disabled';
+                const expectedError = 'CodeEditor cannot simulate change since \
+it is disabled';
 
                 expect( () => driver.change( 'Cthulhu' ) )
                     .toThrow( expectedError );
@@ -270,8 +270,8 @@ simulate change since it is disabled';
             {
                 wrapper.setProps( { isReadOnly: true, label: 'Tekeli-li' } );
 
-                const expectedError = 'CodeEditor \'Tekeli-li\' cannot \
-simulate change since it is read only';
+                const expectedError = 'CodeEditor cannot simulate change since \
+it is read only';
 
                 expect( () => driver.change( 'Azathoth' ) )
                     .toThrow( expectedError );
@@ -315,8 +315,8 @@ simulate change since it is read only';
         {
             test( 'throws the expected error when isDisabled', () =>
             {
-                const expectedError = 'CodeEditor \'Tekeli-li\' cannot \
-simulate mouseOut since it is disabled';
+                const expectedError = 'CodeEditor cannot simulate mouseOut \
+since it is disabled';
                 wrapper.setProps( { isDisabled: true, label: 'Tekeli-li' } );
 
                 expect( () => driver.mouseOut() ).toThrow( expectedError );
@@ -360,8 +360,8 @@ simulate mouseOut since it is disabled';
         {
             test( 'throws the expected error when isDisabled', () =>
             {
-                const expectedError = 'CodeEditor \'Tekeli-li\' cannot \
-simulate mouseOut since it is disabled';
+                const expectedError = 'CodeEditor cannot simulate mouseOut \
+since it is disabled';
                 wrapper.setProps( { isDisabled: true, label: 'Tekeli-li' } );
 
                 expect( () => driver.mouseOut() ).toThrow( expectedError );

--- a/src/DatePicker/driver.js
+++ b/src/DatePicker/driver.js
@@ -7,6 +7,9 @@
  *
  */
 
+import DatePickerHeader from './DatePickerHeader';
+import DatePickerItem   from './DatePickerItem';
+
 const ERR = {
     ITEM_ERR : ( label, state ) =>
         `Item '${label}' cannot be clicked since it is ${state}`,
@@ -24,16 +27,16 @@ export default class DatePickerDriver
     {
         this.wrapper = wrapper;
         this.cssMap  = wrapper.props().cssMap;
-        this.header  = wrapper.find( 'DatePickerHeader' ).props().cssMap;
+        this.header  = wrapper.find( DatePickerHeader ).props().cssMap;
         this.hour    = this.header.hour;
         this.min     = this.header.min;
     }
 
     clickItem( index = 0 )
     {
-        const dateItem = this.wrapper.find( 'DatePickerItem' )
-            .at( index ).props();
-        const { label } = dateItem;
+        const dateItem = this.wrapper.find( DatePickerItem )
+            .at( index );
+        const { label } = dateItem.props();
 
         if ( dateItem.isDisabled )
         {
@@ -45,8 +48,7 @@ export default class DatePickerDriver
             throw new Error( ERR.ITEM_ERR( label, 'read only' ) );
         }
 
-        this.wrapper.find( 'DatePickerItem' ).at( index )
-            .simulate( 'click' );
+        dateItem.simulate( 'click' );
         return this;
     }
 

--- a/src/DatePicker/driver.js
+++ b/src/DatePicker/driver.js
@@ -34,18 +34,13 @@ export default class DatePickerDriver
 
     clickItem( index = 0 )
     {
-        const dateItem = this.wrapper.find( DatePickerItem )
+        const dateItem  = this.wrapper.find( DatePickerItem )
             .at( index );
         const { label } = dateItem.props();
 
         if ( dateItem.isDisabled )
         {
             throw new Error( ERR.ITEM_ERR( label, 'disabled' ) );
-        }
-
-        if ( dateItem.isReadOnly )
-        {
-            throw new Error( ERR.ITEM_ERR( label, 'read only' ) );
         }
 
         dateItem.simulate( 'click' );
@@ -86,13 +81,7 @@ export default class DatePickerDriver
             throw new Error( ERR.TIMEINPUT_ERR( 'keyPress', 'disabled' ) );
         }
 
-        if ( this.wrapper.props().isReadOnly )
-        {
-            throw new Error( ERR.TIMEINPUT_ERR( 'keyPress', 'read only' ) );
-        }
-
-        this.wrapper.find( `.${this.hour}` )
-            .simulate( 'keyPress', { key } );
+        this.wrapper.find( `.${this.hour}` ).simulate( 'keyPress', { key } );
         return this;
     }
 
@@ -108,13 +97,7 @@ export default class DatePickerDriver
             throw new Error( ERR.TIMEINPUT_ERR( 'keyPress', 'disabled' ) );
         }
 
-        if ( this.wrapper.props().isReadOnly )
-        {
-            throw new Error( ERR.TIMEINPUT_ERR( 'keyPress', 'read only' ) );
-        }
-
-        this.wrapper.find( `.${this.min}` )
-            .simulate( 'keyPress', { key } );
+        this.wrapper.find( `.${this.min}` ).simulate( 'keyPress', { key } );
         return this;
     }
 
@@ -128,11 +111,6 @@ export default class DatePickerDriver
         if ( this.wrapper.props().isDisabled )
         {
             throw new Error( ERR.TIMEINPUT_ERR( 'blur', 'disabled' ) );
-        }
-
-        if ( this.wrapper.props().isReadOnly )
-        {
-            throw new Error( ERR.TIMEINPUT_ERR( 'blur', 'read only' ) );
         }
 
         this.wrapper.find( `.${this.hour}` ).simulate( 'blur' );
@@ -151,11 +129,6 @@ export default class DatePickerDriver
             throw new Error( ERR.TIMEINPUT_ERR( 'blur', 'disabled' ) );
         }
 
-        if ( this.wrapper.props().isReadOnly )
-        {
-            throw new Error( ERR.TIMEINPUT_ERR( 'blur', 'read only' ) );
-        }
-
         this.wrapper.find( `.${this.min}` ).simulate( 'blur' );
         return this;
     }
@@ -172,11 +145,6 @@ export default class DatePickerDriver
             throw new Error( ERR.TIMEINPUT_ERR( 'focus', 'disabled' ) );
         }
 
-        if ( this.wrapper.props().isReadOnly )
-        {
-            throw new Error( ERR.TIMEINPUT_ERR( 'focus', 'read only' ) );
-        }
-
         this.wrapper.find( `.${this.hour}` ).simulate( 'focus' );
         return this;
     }
@@ -191,11 +159,6 @@ export default class DatePickerDriver
         if ( this.wrapper.props().isDisabled )
         {
             throw new Error( ERR.TIMEINPUT_ERR( 'focus', 'disabled' ) );
-        }
-
-        if ( this.wrapper.props().isReadOnly )
-        {
-            throw new Error( ERR.TIMEINPUT_ERR( 'focus', 'read only' ) );
         }
 
         this.wrapper.find( `.${this.min}` ).simulate( 'focus' );

--- a/src/DatePicker/tests.jsx
+++ b/src/DatePicker/tests.jsx
@@ -264,39 +264,6 @@ prevIsDisabled', () =>
                 }
             } );
         } );
-
-
-        describe( 'isReadOnly', () =>
-        {
-            test( 'should throw the expected error when isReadOnly', () =>
-            {
-                const expectedError =
-                    'TimeInput cannot simulate blur since it is read only';
-                wrapper.setProps( {
-                    isReadOnly : true,
-                } );
-
-                expect( () => driver.blurHour() ).toThrow( expectedError );
-            } );
-
-            test( 'should not trigger onBlur callback prop when isReadOnly', () =>
-            {
-                const onBlur = jest.fn();
-                wrapper.setProps( {
-                    onBlur,
-                    isReadOnly : true,
-                } );
-
-                try
-                {
-                    driver.blurHour();
-                }
-                catch ( error )
-                {
-                    expect( onBlur ).not.toBeCalled();
-                }
-            } );
-        } );
     } );
 
 
@@ -363,39 +330,6 @@ prevIsDisabled', () =>
                 wrapper.setProps( {
                     onFocus,
                     isDisabled : true,
-                } );
-
-                try
-                {
-                    driver.focusHour();
-                }
-                catch ( error )
-                {
-                    expect( onFocus ).not.toBeCalled();
-                }
-            } );
-        } );
-
-
-        describe( 'isReadOnly', () =>
-        {
-            test( 'should throw the expected error when isReadOnly', () =>
-            {
-                const expectedError =
-                    'TimeInput cannot simulate focus since it is read only';
-                wrapper.setProps( {
-                    isReadOnly : true,
-                } );
-
-                expect( () => driver.focusHour() ).toThrow( expectedError );
-            } );
-
-            test( 'should not trigger onFocus callback prop when isReadOnly', () =>
-            {
-                const onFocus = jest.fn();
-                wrapper.setProps( {
-                    onFocus,
-                    isReadOnly : true,
                 } );
 
                 try
@@ -596,39 +530,6 @@ prevIsDisabled', () =>
                 }
             } );
         } );
-
-
-        describe( 'isReadOnly', () =>
-        {
-            test( 'should throw the expected error when isReadOnly', () =>
-            {
-                const expectedError =
-                    'TimeInput cannot simulate keyPress since it is read only';
-                wrapper.setProps( {
-                    isReadOnly : true,
-                } );
-
-                expect( () => driver.keyPressHour() ).toThrow( expectedError );
-            } );
-
-            test( 'should not trigger onKeyPress callback prop when isReadOnly', () =>
-            {
-                const onKeyPress = jest.fn();
-                wrapper.setProps( {
-                    onKeyPress,
-                    isReadOnly : true,
-                } );
-
-                try
-                {
-                    driver.keyPressHour();
-                }
-                catch ( error )
-                {
-                    expect( onKeyPress ).not.toBeCalled();
-                }
-            } );
-        } );
     } );
 
 
@@ -701,36 +602,6 @@ prevIsDisabled', () =>
                 }
             } );
         } );
-
-
-        describe( 'isReadOnly', () =>
-        {
-            test( 'should throw the expected error when isReadOnly', () =>
-            {
-                const expectedError =
-                    'TimeInput cannot simulate blur since it is read only';
-                wrapper.setProps( {
-                    isReadOnly : true,
-                } );
-
-                expect( () => driver.blurMinute() ).toThrow( expectedError );
-            } );
-
-            test( 'should not trigger onBlur callback prop when isReadOnly', () =>
-            {
-                const onBlur = jest.fn();
-                wrapper.setProps( { onBlur, isReadOnly: true } );
-
-                try
-                {
-                    driver.blurMinute();
-                }
-                catch ( error )
-                {
-                    expect( onBlur ).not.toBeCalled();
-                }
-            } );
-        } );
     } );
 
 
@@ -792,36 +663,6 @@ prevIsDisabled', () =>
             {
                 const onFocus = jest.fn();
                 wrapper.setProps( { onFocus, isDisabled: true } );
-
-                try
-                {
-                    driver.focusMinute();
-                }
-                catch ( error )
-                {
-                    expect( onFocus ).not.toBeCalled();
-                }
-            } );
-        } );
-
-
-        describe( 'isReadOnly', () =>
-        {
-            test( 'should throw the expected error when isReadOnly', () =>
-            {
-                const expectedError =
-                    'TimeInput cannot simulate focus since it is read only';
-                wrapper.setProps( {
-                    isReadOnly : true,
-                } );
-
-                expect( () => driver.focusMinute() ).toThrow( expectedError );
-            } );
-
-            test( 'should not trigger onFocus callback prop when isReadOnly', () =>
-            {
-                const onFocus = jest.fn();
-                wrapper.setProps( { onFocus, isReadOnly: true } );
 
                 try
                 {
@@ -1004,39 +845,6 @@ not <default>', () =>
                 wrapper.setProps( {
                     onKeyPress,
                     isDisabled : true,
-                } );
-
-                try
-                {
-                    driver.keyPressMinute();
-                }
-                catch ( error )
-                {
-                    expect( onKeyPress ).not.toBeCalled();
-                }
-            } );
-        } );
-
-
-        describe( 'isReadOnly', () =>
-        {
-            test( 'should throw the expected error when isReadOnly', () =>
-            {
-                const expectedError =
-                    'Input cannot simulate keyPress since it is read only';
-                wrapper.setProps( {
-                    isReadOnly : true,
-                } );
-
-                expect( () => driver.keyPressMinute() ).toThrow( expectedError );
-            } );
-
-            test( 'should not trigger onKeyPress callback prop when isReadOnly', () =>
-            {
-                const onKeyPress = jest.fn();
-                wrapper.setProps( {
-                    onKeyPress,
-                    isReadOnly : true,
                 } );
 
                 try

--- a/src/DateTimeInput/driver.js
+++ b/src/DateTimeInput/driver.js
@@ -71,8 +71,9 @@ export default class DateTimeInputDriver
 
     clickCellByValue( value )
     {
-        const day = this.calendar.findWhere( n =>
-            n.prop( 'value' ) === value ).first();
+        const day = this.calendar.findWhere( n => n.prop( 'value' ) === value )
+            .first();
+
         day.simulate( 'click' );
         return this;
     }

--- a/src/Fieldset/driver.js
+++ b/src/Fieldset/driver.js
@@ -1,8 +1,3 @@
-const ERR = {
-    FIELDSET_ERR : ( event ) =>
-        `Fieldset cannot simulate ${event} because it is disabled`,
-};
-
 export default class FieldsetDriver
 {
     constructor( wrapper )

--- a/src/Fieldset/driver.js
+++ b/src/Fieldset/driver.js
@@ -3,7 +3,7 @@ const ERR = {
         `Fieldset cannot simulate ${event} because it is disabled`,
 };
 
-export default class DatePickerDriver
+export default class FieldsetDriver
 {
     constructor( wrapper )
     {
@@ -12,22 +12,12 @@ export default class DatePickerDriver
 
     mouseOver()
     {
-        if ( this.wrapper.props().isDisabled )
-        {
-            throw new Error( ERR.FIELDSET_ERR( 'mouseOver' ) );
-        }
-
         this.wrapper.simulate( 'mouseenter' );
         return this;
     }
 
     mouseOut()
     {
-        if ( this.wrapper.props().isDisabled )
-        {
-            throw new Error( ERR.FIELDSET_ERR( 'mouseOut' ) );
-        }
-
         this.wrapper.simulate( 'mouseleave' );
         return this;
     }

--- a/src/Fieldset/tests.jsx
+++ b/src/Fieldset/tests.jsx
@@ -100,34 +100,6 @@ describe( 'FieldsetDriver', () =>
             driver.mouseOver();
             expect( onMouseOver ).toBeCalledTimes( 1 );
         } );
-
-
-        describe( 'isDisabled', () =>
-        {
-            test( 'should throw the expected error when isDisabled', () =>
-            {
-                const expectedError =
-                    'Fieldset cannot simulate mouseOver because it is disabled';
-                wrapper.setProps( { isDisabled: true } );
-
-                expect( () => driver.mouseOver() ).toThrow( expectedError );
-            } );
-
-            test( 'should not trigger onMouseOver when isDisabled', () =>
-            {
-                const onMouseOver = jest.fn();
-                wrapper.setProps( { onMouseOver, isDisabled: true } );
-
-                try
-                {
-                    driver.mouseOver();
-                }
-                catch ( error )
-                {
-                    expect( onMouseOver ).not.toBeCalled();
-                }
-            } );
-        } );
     } );
 
 
@@ -140,34 +112,6 @@ describe( 'FieldsetDriver', () =>
 
             driver.mouseOut();
             expect( onMouseOut ).toBeCalledTimes( 1 );
-        } );
-
-
-        describe( 'isDisabled', () =>
-        {
-            test( 'should throw the expected error when isDisabled', () =>
-            {
-                const expectedError =
-                    'Fieldset cannot simulate mouseOut because it is disabled';
-                wrapper.setProps( { isDisabled: true } );
-
-                expect( () => driver.mouseOut() ).toThrow( expectedError );
-            } );
-
-            test( 'should not trigger onMouseOut when isDisabled', () =>
-            {
-                const onMouseOut = jest.fn();
-                wrapper.setProps( { onMouseOut, isDisabled: true } );
-
-                try
-                {
-                    driver.mouseOver();
-                }
-                catch ( error )
-                {
-                    expect( onMouseOut ).not.toBeCalled();
-                }
-            } );
         } );
     } );
 } );

--- a/src/FlounderDropdown/driver.js
+++ b/src/FlounderDropdown/driver.js
@@ -20,13 +20,16 @@
  * otherwise I think it's possible to change the elements through
  * this.flounderControl.refs and re-render the wrapper.
  */
+
+import InputContainer from '../proto/InputContainer';
+
 export default class FlounderDropdownDriver
 {
     constructor( wrapper )
     {
         // Nessie Control
         this.wrapper = wrapper;
-        this.control = wrapper.find( 'InputContainer' );
+        this.control = wrapper.find( InputContainer );
         // the 3rd party control
         this.innerFlounderComponent = wrapper.node.flounderInstance;
     }

--- a/src/IconButton/driver.js
+++ b/src/IconButton/driver.js
@@ -29,12 +29,6 @@ export default class IconButtonDriver
                 .ICONBUTTON_ERR( label, 'click', 'read only' ) );
         }
 
-        if ( props.isLoading )
-        {
-            throw new Error( ERR
-                .ICONBUTTON_ERR( label, 'click', 'loading' ) );
-        }
-
         this.button.simulate( 'click' );
         return this;
     }
@@ -48,12 +42,6 @@ export default class IconButtonDriver
         {
             throw new Error( ERR
                 .ICONBUTTON_ERR( label, 'mouseOver', 'disabled' ) );
-        }
-
-        if ( props.isLoading )
-        {
-            throw new Error( ERR
-                .ICONBUTTON_ERR( label, 'mouseOver', 'loading' ) );
         }
 
         this.button.simulate( 'mouseenter' );
@@ -71,12 +59,6 @@ export default class IconButtonDriver
                 .ICONBUTTON_ERR( label, 'mouseOut', 'disabled' ) );
         }
 
-        if ( props.isLoading )
-        {
-            throw new Error( ERR
-                .ICONBUTTON_ERR( label, 'mouseOut', 'loading' ) );
-        }
-
         this.button.simulate( 'mouseleave' );
         return this;
     }
@@ -91,17 +73,6 @@ export default class IconButtonDriver
             throw new Error( ERR.ICONBUTTON_ERR( label, 'focus', 'disabled' ) );
         }
 
-        if ( props.isReadOnly )
-        {
-            throw new Error( ERR
-                .ICONBUTTON_ERR( label, 'focus', 'read only' ) );
-        }
-
-        if ( props.isLoading )
-        {
-            throw new Error( ERR.ICONBUTTON_ERR( label, 'focus', 'loading' ) );
-        }
-
         this.button.simulate( 'focus' );
         return this;
     }
@@ -114,16 +85,6 @@ export default class IconButtonDriver
         if ( props.isDisabled )
         {
             throw new Error( ERR.ICONBUTTON_ERR( label, 'blur', 'disabled' ) );
-        }
-
-        if ( props.isReadOnly )
-        {
-            throw new Error( ERR.ICONBUTTON_ERR( label, 'blur', 'read only' ) );
-        }
-
-        if ( props.isLoading )
-        {
-            throw new Error( ERR.ICONBUTTON_ERR( label, 'blur', 'loading' ) );
         }
 
         this.button.simulate( 'blur' );

--- a/src/IconButton/driver.js
+++ b/src/IconButton/driver.js
@@ -14,7 +14,7 @@ export default class IconButtonDriver
 
     click()
     {
-        const props = this.wrapper.props();
+        const props     = this.wrapper.props();
         const { label } = props;
 
         if ( props.isDisabled )
@@ -35,7 +35,7 @@ export default class IconButtonDriver
 
     mouseOver()
     {
-        const props = this.wrapper.props();
+        const props     = this.wrapper.props();
         const { label } = props;
 
         if ( props.isDisabled )
@@ -50,7 +50,7 @@ export default class IconButtonDriver
 
     mouseOut()
     {
-        const props = this.wrapper.props();
+        const props     = this.wrapper.props();
         const { label } = props;
 
         if ( props.isDisabled )
@@ -65,7 +65,7 @@ export default class IconButtonDriver
 
     focus()
     {
-        const props = this.wrapper.props();
+        const props     = this.wrapper.props();
         const { label } = props;
 
         if ( props.isDisabled )
@@ -79,7 +79,7 @@ export default class IconButtonDriver
 
     blur()
     {
-        const props = this.wrapper.props();
+        const props     = this.wrapper.props();
         const { label } = props;
 
         if ( props.isDisabled )

--- a/src/IconButton/tests.jsx
+++ b/src/IconButton/tests.jsx
@@ -150,10 +150,9 @@ click since it is disabled';
         {
             test( 'throws the expected error when isReadOnly', () =>
             {
-                wrapper.setProps( { isReadOnly: true, label: 'Tekeli-li' } );
-
                 const expectedError = 'Button \'Tekeli-li\' cannot simulate \
 click since it is read only';
+                wrapper.setProps( { isReadOnly: true, label: 'Tekeli-li' } );
 
                 expect( () => driver.click() ).toThrow( expectedError );
             } );
@@ -196,10 +195,9 @@ click since it is read only';
         {
             test( 'throws the expected error when isDisabled', () =>
             {
-                wrapper.setProps( { isDisabled: true, label: 'Tekeli-li' } );
-
                 const expectedError = 'Button \'Tekeli-li\' cannot simulate \
 blur since it is disabled';
+                wrapper.setProps( { isDisabled: true, label: 'Tekeli-li' } );
 
                 expect( () => driver.blur() ).toThrow( expectedError );
             } );

--- a/src/IconButton/tests.jsx
+++ b/src/IconButton/tests.jsx
@@ -177,39 +177,6 @@ click since it is read only';
                 }
             } );
         } );
-
-
-        describe( 'isLoading', () =>
-        {
-            test( 'throws the expected error when isLoading', () =>
-            {
-                wrapper.setProps( { isLoading: true, label: 'Tekeli-li'  } );
-
-                const expectedError = 'Button \'Tekeli-li\' cannot simulate \
-click since it is loading';
-
-                expect( () => driver.click() ).toThrow( expectedError );
-            } );
-
-            test( 'should not trigger onClick when isLoading', () =>
-            {
-                const onClick = jest.fn();
-                wrapper.setProps( {
-                    onClick,
-                    isLoading : true,
-                    label     : 'Tekeli-li',
-                } );
-
-                try
-                {
-                    driver.click();
-                }
-                catch ( error )
-                {
-                    expect( onClick ).not.toBeCalled();
-                }
-            } );
-        } );
     } );
 
 
@@ -256,70 +223,6 @@ blur since it is disabled';
                 }
             } );
         } );
-
-
-        describe( 'isReadOnly', () =>
-        {
-            test( 'throws the expected error when isReadOnly', () =>
-            {
-                const expectedError = 'Button \'Tekeli-li\' cannot simulate \
-blur since it is read only';
-                wrapper.setProps( { isReadOnly: true, label: 'Tekeli-li' } );
-
-                expect( () => driver.blur() ).toThrow( expectedError );
-            } );
-
-            test( 'should not trigger onBlur when isReadOnly', () =>
-            {
-                const onBlur = jest.fn();
-                wrapper.setProps( {
-                    onBlur,
-                    isReadOnly : true,
-                    label      : 'Tekeli-li',
-                } );
-
-                try
-                {
-                    driver.blur();
-                }
-                catch ( error )
-                {
-                    expect( onBlur ).not.toBeCalled();
-                }
-            } );
-        } );
-
-
-        describe( 'isLoading', () =>
-        {
-            test( 'throws the expected error when isLoading', () =>
-            {
-                const expectedError = 'Button \'Tekeli-li\' cannot simulate \
-blur since it is loading';
-                wrapper.setProps( { isLoading: true, label: 'Tekeli-li'  } );
-
-                expect( () => driver.blur() ).toThrow( expectedError );
-            } );
-
-            test( 'should not trigger onBlur when isLoading', () =>
-            {
-                const onBlur = jest.fn();
-                wrapper.setProps( {
-                    onBlur,
-                    isLoading : true,
-                    label     : 'Tekeli-li',
-                } );
-
-                try
-                {
-                    driver.blur();
-                }
-                catch ( error )
-                {
-                    expect( onBlur ).not.toBeCalled();
-                }
-            } );
-        } );
     } );
 
 
@@ -353,72 +256,6 @@ focus since it is disabled';
                     onFocus,
                     isDisabled : true,
                     label      : 'Tekeli-li',
-                } );
-
-                try
-                {
-                    driver.focus();
-                }
-                catch ( error )
-                {
-                    expect( onFocus ).not.toBeCalled();
-                }
-            } );
-        } );
-
-
-        describe( 'isReadOnly', () =>
-        {
-            test( 'throws the expected error when isReadOnly', () =>
-            {
-                wrapper.setProps( { isReadOnly: true, label: 'Tekeli-li' } );
-
-                const expectedError = 'Button \'Tekeli-li\' cannot simulate \
-focus since it is read only';
-
-                expect( () => driver.focus() ).toThrow( expectedError );
-            } );
-
-            test( 'should not trigger onFocus when isReadOnly', () =>
-            {
-                const onFocus = jest.fn();
-                wrapper.setProps( {
-                    onFocus,
-                    isReadOnly : true,
-                    label      : 'Tekeli-li',
-                } );
-
-                try
-                {
-                    driver.focus();
-                }
-                catch ( error )
-                {
-                    expect( onFocus ).not.toBeCalled();
-                }
-            } );
-        } );
-
-
-        describe( 'isLoading', () =>
-        {
-            test( 'throws the expected error when isLoading', () =>
-            {
-                wrapper.setProps( { isLoading: true, label: 'Tekeli-li'  } );
-
-                const expectedError = 'Button \'Tekeli-li\' cannot simulate \
-focus since it is loading';
-
-                expect( () => driver.focus() ).toThrow( expectedError );
-            } );
-
-            test( 'should not trigger onFocus when isLoading', () =>
-            {
-                const onFocus = jest.fn();
-                wrapper.setProps( {
-                    onFocus,
-                    isLoading : true,
-                    label     : 'Tekeli-li',
                 } );
 
                 try

--- a/src/IconWithTooltip/driver.js
+++ b/src/IconWithTooltip/driver.js
@@ -7,11 +7,6 @@
  *
  */
 
-const ERR = {
-    ICONWITHTOOLTIP_ERR : ( event ) =>
-        `IconWithTooltip cannot simulate ${event} because it is disabled`,
-};
-
 export default class IconWithTooltipDriver
 {
     constructor( wrapper )
@@ -23,44 +18,24 @@ export default class IconWithTooltipDriver
 
     mouseOverIcon()
     {
-        if ( this.wrapper.props().isDisabled )
-        {
-            throw new Error( ERR.ICONWITHTOOLTIP_ERR( 'mouseOverIcon' ) );
-        }
-
         this.tooltip.simulate( 'mouseenter' );
         return this;
     }
 
     mouseOutIcon()
     {
-        if ( this.wrapper.props().isDisabled )
-        {
-            throw new Error( ERR.ICONWITHTOOLTIP_ERR( 'mouseOutIcon' ) );
-        }
-
         this.tooltip.simulate( 'mouseleave' );
         return this;
     }
 
     mouseOver()
     {
-        if ( this.wrapper.props().isDisabled )
-        {
-            throw new Error( ERR.ICONWITHTOOLTIP_ERR( 'mouseOver' ) );
-        }
-
         this.wrapper.simulate( 'mouseenter' );
         return this;
     }
 
     mouseOut()
     {
-        if ( this.wrapper.props().isDisabled )
-        {
-            throw new Error( ERR.ICONWITHTOOLTIP_ERR( 'mouseOut' ) );
-        }
-
         this.wrapper.simulate( 'mouseleave' );
         return this;
     }

--- a/src/IconWithTooltip/tests.jsx
+++ b/src/IconWithTooltip/tests.jsx
@@ -129,34 +129,6 @@ describe( 'IconWithTooltipDriver', () =>
             driver.mouseOver();
             expect( onMouseOver ).toBeCalledTimes( 1 );
         } );
-
-
-        describe( 'isDisabled', () =>
-        {
-            test( 'throws the expected error when isDisabled', () =>
-            {
-                const expectedError = 'IconWithTooltip cannot simulate \
-mouseOver because it is disabled';
-                wrapper.setProps( { isDisabled: true } );
-
-                expect( () => driver.mouseOver() ).toThrow( expectedError );
-            } );
-
-            test( 'shoud not trigger onMouseOver when isDisabled', () =>
-            {
-                const onMouseOver = jest.fn();
-                wrapper.setProps( { onMouseOver, isDisabled: true } );
-
-                try
-                {
-                    driver.mouseOver();
-                }
-                catch ( error )
-                {
-                    expect( onMouseOver ).not.toBeCalled();
-                }
-            } );
-        } );
     } );
 
 
@@ -169,34 +141,6 @@ mouseOver because it is disabled';
 
             driver.mouseOut();
             expect( onMouseOut ).toBeCalledTimes( 1 );
-        } );
-
-
-        describe( 'isDisabled', () =>
-        {
-            test( 'throws the expected error when isDisabled', () =>
-            {
-                const expectedError = 'IconWithTooltip cannot simulate \
-mouseOut because it is disabled';
-                wrapper.setProps( { isDisabled: true } );
-
-                expect( () => driver.mouseOut() ).toThrow( expectedError );
-            } );
-
-            test( 'should not trigger onMouseOut when isDisabled', () =>
-            {
-                const onMouseOut = jest.fn();
-                wrapper.setProps( { onMouseOut, isDisabled: true } );
-
-                try
-                {
-                    driver.mouseOut();
-                }
-                catch ( error )
-                {
-                    expect( onMouseOut ).not.toBeCalled();
-                }
-            } );
         } );
     } );
 
@@ -211,34 +155,6 @@ mouseOut because it is disabled';
             driver.mouseOverIcon();
             expect( onMouseOverIcon ).toBeCalledTimes( 1 );
         } );
-
-
-        describe( 'isDisabled', () =>
-        {
-            test( 'throws the expected error when isDisabled', () =>
-            {
-                const expectedError = 'IconWithTooltip cannot simulate \
-mouseOverIcon because it is disabled';
-                wrapper.setProps( { isDisabled: true } );
-
-                expect( () => driver.mouseOverIcon() ).toThrow( expectedError );
-            } );
-
-            test( 'should not trigger onMouseOverIcon when isDisabled', () =>
-            {
-                const onMouseOverIcon = jest.fn();
-                wrapper.setProps( { onMouseOverIcon, isDisabled: true } );
-
-                try
-                {
-                    driver.mouseOverIcon();
-                }
-                catch ( error )
-                {
-                    expect( onMouseOverIcon ).not.toBeCalled();
-                }
-            } );
-        } );
     } );
 
 
@@ -251,34 +167,6 @@ mouseOverIcon because it is disabled';
 
             driver.mouseOutIcon();
             expect( onMouseOutIcon ).toBeCalledTimes( 1 );
-        } );
-
-
-        describe( 'isDisabled', () =>
-        {
-            test( 'throws the expected error when isDisabled', () =>
-            {
-                const expectedError = 'IconWithTooltip cannot simulate \
-mouseOutIcon because it is disabled';
-                wrapper.setProps( { isDisabled: true } );
-
-                expect( () => driver.mouseOutIcon() ).toThrow( expectedError );
-            } );
-
-            test( 'should not trigger onMouseOutIcon when isDisabled', () =>
-            {
-                const onMouseOutIcon = jest.fn();
-                wrapper.setProps( { onMouseOutIcon, isDisabled: true } );
-
-                try
-                {
-                    driver.mouseOutIcon();
-                }
-                catch ( error )
-                {
-                    expect( onMouseOutIcon ).not.toBeCalled();
-                }
-            } );
         } );
     } );
 } );

--- a/src/InputField/driver.js
+++ b/src/InputField/driver.js
@@ -18,12 +18,6 @@ export default class InputFieldDriver
                 .INPUTFIELD_ERROR( 'blur', 'disabled' ) );
         }
 
-        if ( this.wrapper.props().isReadOnly )
-        {
-            throw new Error( ERR
-                .INPUTFIELD_ERROR( 'blur', 'read only' ) );
-        }
-
         this.wrapper.simulate( 'blur' );
         return this;
     }
@@ -34,12 +28,6 @@ export default class InputFieldDriver
         {
             throw new Error( ERR
                 .INPUTFIELD_ERROR( 'focus', 'disabled' ) );
-        }
-
-        if ( this.wrapper.props().isReadOnly )
-        {
-            throw new Error( ERR
-                .INPUTFIELD_ERROR( 'focus', 'read only' ) );
         }
 
         this.wrapper.simulate( 'focus' );
@@ -76,12 +64,6 @@ export default class InputFieldDriver
                 .INPUTFIELD_ERROR( 'click', 'disabled' ) );
         }
 
-        if ( this.wrapper.props().isReadOnly )
-        {
-            throw new Error( ERR
-                .INPUTFIELD_ERROR( 'click', 'read only' ) );
-        }
-
         this.wrapper.simulate( 'click' );
         return this;
     }
@@ -92,12 +74,6 @@ export default class InputFieldDriver
         {
             throw new Error( ERR
                 .INPUTFIELD_ERROR( 'keyPress', 'disabled' ) );
-        }
-
-        if ( this.wrapper.props().isReadOnly )
-        {
-            throw new Error( ERR
-                .INPUTFIELD_ERROR( 'keyPress', 'read only' ) );
         }
 
         this.wrapper.simulate( 'keyPress', { keyCode } );
@@ -112,12 +88,6 @@ export default class InputFieldDriver
                 .INPUTFIELD_ERROR( 'keyDown', 'disabled' ) );
         }
 
-        if ( this.wrapper.props().isReadOnly )
-        {
-            throw new Error( ERR
-                .INPUTFIELD_ERROR( 'keyDown', 'read only' ) );
-        }
-
         this.wrapper.simulate( 'keyDown', { keyCode } );
         return this;
     }
@@ -130,48 +100,18 @@ export default class InputFieldDriver
                 .INPUTFIELD_ERROR( 'keyUp', 'disabled' ) );
         }
 
-        if ( this.wrapper.props().isReadOnly )
-        {
-            throw new Error( ERR
-                .INPUTFIELD_ERROR( 'keyUp', 'read only' ) );
-        }
-
         this.wrapper.simulate( 'keyUp', { keyCode } );
         return this;
     }
 
     mouseOver()
     {
-        if ( this.wrapper.props().isDisabled )
-        {
-            throw new Error( ERR
-                .INPUTFIELD_ERROR( 'mouseOver', 'disabled' ) );
-        }
-
-        if ( this.wrapper.props().isReadOnly )
-        {
-            throw new Error( ERR
-                .INPUTFIELD_ERROR( 'mouseOver', 'read only' ) );
-        }
-
         this.wrapper.simulate( 'mouseenter' );
         return this;
     }
 
     mouseOut()
     {
-        if ( this.wrapper.props().isDisabled )
-        {
-            throw new Error( ERR
-                .INPUTFIELD_ERROR( 'mouseOut', 'disabled' ) );
-        }
-
-        if ( this.wrapper.props().isReadOnly )
-        {
-            throw new Error( ERR
-                .INPUTFIELD_ERROR( 'mouseOut', 'read only' ) );
-        }
-
         this.wrapper.simulate( 'mouseleave' );
         return this;
     }

--- a/src/InputField/tests.jsx
+++ b/src/InputField/tests.jsx
@@ -183,7 +183,6 @@ describe( 'InputField', () =>
             test( 'should be passed to the InputField', () =>
             {
                 const onChange = () => undefined;
-
                 wrapper.setProps( { onChange } );
 
                 expect( wrapper.find( InputField ).prop( 'onChange' ) )
@@ -209,7 +208,6 @@ describe( 'InputField', () =>
             test( 'should be passed to the InputField', () =>
             {
                 const onKeyPress = () => undefined;
-
                 wrapper.setProps( { onKeyPress } );
 
                 expect( wrapper.find( InputField ).prop( 'onKeyPress' ) )
@@ -227,7 +225,6 @@ describe( 'InputField', () =>
             test( 'should be passed to the InputField', () =>
             {
                 const onMouseOut = () => undefined;
-
                 wrapper.setProps( { onMouseOut } );
 
                 expect( wrapper.find( InputField ).prop( 'onMouseOut' ) )
@@ -245,7 +242,6 @@ describe( 'InputField', () =>
             test( 'should be passed to the InputField', () =>
             {
                 const onMouseOver = () => undefined;
-
                 wrapper.setProps( { onMouseOver } );
 
                 expect( wrapper.find( InputField ).prop( 'onMouseOver' ) )
@@ -370,34 +366,6 @@ describe( 'InputFieldDriver', () =>
                 }
             } );
         } );
-
-
-        describe( 'isReadOnly', () =>
-        {
-            test( 'throws the expected error when isReadOnly', () =>
-            {
-                const expectedError =
-                    'InputField cannot simulate blur since it is read only';
-                wrapper.setProps( { isReadOnly: true } );
-
-                expect( () => driver.blur() ).toThrow( expectedError );
-            } );
-
-            test( 'should not trigger onBlur when isReadOnly', () =>
-            {
-                const onBlur = jest.fn();
-                wrapper.setProps( { onBlur, isReadOnly: true } );
-
-                try
-                {
-                    driver.blur();
-                }
-                catch ( error )
-                {
-                    expect( onBlur ).not.toBeCalled();
-                }
-            } );
-        } );
     } );
 
 
@@ -428,34 +396,6 @@ describe( 'InputFieldDriver', () =>
             {
                 const onFocus = jest.fn();
                 wrapper.setProps( { onFocus, isDisabled: true } );
-
-                try
-                {
-                    driver.focus();
-                }
-                catch ( error )
-                {
-                    expect( onFocus ).not.toBeCalled();
-                }
-            } );
-        } );
-
-
-        describe( 'isReadOnly', () =>
-        {
-            test( 'throws the expected error when isReadOnly', () =>
-            {
-                const expectedError =
-                    'InputField cannot simulate focus since it is read only';
-                wrapper.setProps( { isReadOnly: true } );
-
-                expect( () => driver.focus() ).toThrow( expectedError );
-            } );
-
-            test( 'should not trigger onFocus when isReadOnly', () =>
-            {
-                const onFocus = jest.fn();
-                wrapper.setProps( { onFocus, isReadOnly: true } );
 
                 try
                 {
@@ -577,34 +517,6 @@ describe( 'InputFieldDriver', () =>
                 }
             } );
         } );
-
-
-        describe( 'isReadOnly', () =>
-        {
-            test( 'throws the expected error when isReadOnly', () =>
-            {
-                const expectedError =
-                    'InputField cannot simulate click since it is read only';
-                wrapper.setProps( { isReadOnly: true } );
-
-                expect( () => driver.click() ).toThrow( expectedError );
-            } );
-
-            test( 'should not trigger onClick when isReadOnly', () =>
-            {
-                const onClick = jest.fn();
-                wrapper.setProps( { onClick, isReadOnly: true } );
-
-                try
-                {
-                    driver.click();
-                }
-                catch ( error )
-                {
-                    expect( onClick ).not.toBeCalled();
-                }
-            } );
-        } );
     } );
 
 
@@ -635,34 +547,6 @@ describe( 'InputFieldDriver', () =>
             {
                 const onKeyPress = jest.fn();
                 wrapper.setProps( { onKeyPress, isDisabled: true } );
-
-                try
-                {
-                    driver.keyPress();
-                }
-                catch ( error )
-                {
-                    expect( onKeyPress ).not.toBeCalled();
-                }
-            } );
-        } );
-
-
-        describe( 'isReadOnly', () =>
-        {
-            test( 'throws the expected error when isReadOnly', () =>
-            {
-                const expectedError =
-                    'InputField cannot simulate keyPress since it is read only';
-                wrapper.setProps( { isReadOnly: true } );
-
-                expect( () => driver.keyPress() ).toThrow( expectedError );
-            } );
-
-            test( 'should not trigger onKeyPress when isReadOnly', () =>
-            {
-                const onKeyPress = jest.fn();
-                wrapper.setProps( { onKeyPress, isReadOnly: true } );
 
                 try
                 {
@@ -715,34 +599,6 @@ describe( 'InputFieldDriver', () =>
                 }
             } );
         } );
-
-
-        describe( 'isReadOnly', () =>
-        {
-            test( 'throws the expected error when isReadOnly', () =>
-            {
-                const expectedError =
-                    'InputField cannot simulate keyDown since it is read only';
-                wrapper.setProps( { isReadOnly: true } );
-
-                expect( () => driver.keyDown() ).toThrow( expectedError );
-            } );
-
-            test( 'should not trigger onKeyDown when isReadOnly', () =>
-            {
-                const onKeyDown = jest.fn();
-                wrapper.setProps( { onKeyDown, isReadOnly: true } );
-
-                try
-                {
-                    driver.keyDown();
-                }
-                catch ( error )
-                {
-                    expect( onKeyDown ).not.toBeCalled();
-                }
-            } );
-        } );
     } );
 
 
@@ -784,34 +640,6 @@ describe( 'InputFieldDriver', () =>
                 }
             } );
         } );
-
-
-        describe( 'isReadOnly', () =>
-        {
-            test( 'throws the expected error when isReadOnly', () =>
-            {
-                const expectedError =
-                    'InputField cannot simulate keyUp since it is read only';
-                wrapper.setProps( { isReadOnly: true } );
-
-                expect( () => driver.keyUp() ).toThrow( expectedError );
-            } );
-
-            test( 'should not trigger onKeyUp when isReadOnly', () =>
-            {
-                const onKeyUp = jest.fn();
-                wrapper.setProps( { onKeyUp, isReadOnly: true } );
-
-                try
-                {
-                    driver.keyUp();
-                }
-                catch ( error )
-                {
-                    expect( onKeyUp ).not.toBeCalled();
-                }
-            } );
-        } );
     } );
 
 
@@ -825,62 +653,6 @@ describe( 'InputFieldDriver', () =>
             driver.mouseOver();
             expect( onMouseOver ).toBeCalledTimes( 1 );
         } );
-
-
-        describe( 'isDisabled', () =>
-        {
-            test( 'throws the expected error when isDisabled', () =>
-            {
-                const expectedError =
-                    'InputField cannot simulate mouseOver since it is disabled';
-                wrapper.setProps( { isDisabled: true } );
-
-                expect( () => driver.mouseOver() ).toThrow( expectedError );
-            } );
-
-            test( 'should not trigger onMouseOver when isDisabled', () =>
-            {
-                const onMouseOver = jest.fn();
-                wrapper.setProps( { onMouseOver, isDisabled: true } );
-
-                try
-                {
-                    driver.mouseOver();
-                }
-                catch ( error )
-                {
-                    expect( onMouseOver ).not.toBeCalled();
-                }
-            } );
-        } );
-
-
-        describe( 'isReadOnly', () =>
-        {
-            test( 'throws the expected error when isReadOnly', () =>
-            {
-                const expectedError = 'InputField cannot simulate mouseOver \
-since it is read only';
-                wrapper.setProps( { isReadOnly: true } );
-
-                expect( () => driver.mouseOver() ).toThrow( expectedError );
-            } );
-
-            test( 'should not trigger onMouseOver when isReadOnly', () =>
-            {
-                const onMouseOver = jest.fn();
-                wrapper.setProps( { onMouseOver, isReadOnly: true } );
-
-                try
-                {
-                    driver.mouseOver();
-                }
-                catch ( error )
-                {
-                    expect( onMouseOver ).not.toBeCalled();
-                }
-            } );
-        } );
     } );
 
 
@@ -893,62 +665,6 @@ since it is read only';
 
             driver.mouseOut();
             expect( onMouseOut ).toBeCalledTimes( 1 );
-        } );
-
-
-        describe( 'isDisabled', () =>
-        {
-            test( 'throws the expected error when isDisabled', () =>
-            {
-                const expectedError =
-                    'InputField cannot simulate mouseOut since it is disabled';
-                wrapper.setProps( { isDisabled: true } );
-
-                expect( () => driver.mouseOut() ).toThrow( expectedError );
-            } );
-
-            test( 'should not trigger onMouseOut when isDisabled', () =>
-            {
-                const onMouseOut = jest.fn();
-                wrapper.setProps( { onMouseOut, isDisabled: true } );
-
-                try
-                {
-                    driver.mouseOut();
-                }
-                catch ( error )
-                {
-                    expect( onMouseOut ).not.toBeCalled();
-                }
-            } );
-        } );
-
-
-        describe( 'isReadOnly', () =>
-        {
-            test( 'throws the expected error when isReadOnly', () =>
-            {
-                const expectedError =
-                    'InputField cannot simulate mouseOut since it is read only';
-                wrapper.setProps( { isReadOnly: true } );
-
-                expect( () => driver.mouseOut() ).toThrow( expectedError );
-            } );
-
-            test( 'should not trigger onMouseOut when isReadOnly', () =>
-            {
-                const onMouseOut = jest.fn();
-                wrapper.setProps( { onMouseOut, isReadOnly: true } );
-
-                try
-                {
-                    driver.mouseOut();
-                }
-                catch ( error )
-                {
-                    expect( onMouseOut ).not.toBeCalled();
-                }
-            } );
         } );
     } );
 } );

--- a/src/ListBox/driver.js
+++ b/src/ListBox/driver.js
@@ -7,6 +7,7 @@
  *
  */
 
+import ListBoxOption from './ListBoxOption';
 
 export default class ListBoxDriver
 {
@@ -17,7 +18,7 @@ export default class ListBoxDriver
 
     clickOption( index = 0 )
     {
-        const option = this.wrapper.find( 'ListBoxOption' ).at( index );
+        const option = this.wrapper.find( ListBoxOption ).at( index );
 
         option.simulate( 'click' );
         return this;
@@ -25,7 +26,7 @@ export default class ListBoxDriver
 
     mouseOverOption( index = 0 )
     {
-        const option = this.wrapper.find( 'ListBoxOption' ).at( index );
+        const option = this.wrapper.find( ListBoxOption ).at( index );
 
         option.simulate( 'mouseenter' );
         return this;
@@ -33,7 +34,7 @@ export default class ListBoxDriver
 
     mouseOutOption( index = 0 )
     {
-        const option = this.wrapper.find( 'ListBoxOption' ).at( index );
+        const option = this.wrapper.find( ListBoxOption ).at( index );
 
         option.simulate( 'mouseleave' );
         return this;

--- a/src/ModalDialog/driver.js
+++ b/src/ModalDialog/driver.js
@@ -20,9 +20,7 @@ export default class ModalDialogDriver
     {
         this.wrapper = wrapper;
         this.cssMap  = wrapper.props().cssMap;
-
         this.overlay = wrapper.find( `.${this.cssMap.default}` );
-        this.content = wrapper.find( `.${this.cssMap.content}` );
 
         this.closeButton = wrapper.find( `.${this.cssMap.header}` )
             .find( IconButton );
@@ -35,6 +33,7 @@ export default class ModalDialogDriver
     clickOverlay()
     {
         this.overlay.simulate( 'click' );
+        return this;
     }
 
     clickClose()
@@ -43,7 +42,9 @@ export default class ModalDialogDriver
         {
             throw new Error( ERR.NOT_A_CAROUSEL( 'Close Button' ) );
         }
+
         this.closeButton.driver().click();
+        return this;
     }
 
     clickPrev()
@@ -52,7 +53,9 @@ export default class ModalDialogDriver
         {
             throw new Error( ERR.NOT_A_CAROUSEL( 'Prev Button' ) );
         }
+
         this.prevButton.driver().click();
+        return this;
     }
 
     clickNext()
@@ -61,6 +64,8 @@ export default class ModalDialogDriver
         {
             throw new Error( ERR.NOT_A_CAROUSEL( 'Next Button' ) );
         }
+
         this.nextButton.driver().click();
+        return this;
     }
 }

--- a/src/ModalDialog/driver.js
+++ b/src/ModalDialog/driver.js
@@ -24,9 +24,9 @@ export default class ModalDialogDriver
 
         this.closeButton = wrapper.find( `.${this.cssMap.header}` )
             .find( IconButton );
-        this.prevButton = wrapper.find( `.${this.cssMap.navigation}` )
+        this.prevButton  = wrapper.find( `.${this.cssMap.navigation}` )
             .find( IconButton ).first();
-        this.nextButton = wrapper.find( `.${this.cssMap.navigation}` )
+        this.nextButton  = wrapper.find( `.${this.cssMap.navigation}` )
             .find( IconButton ).last();
     }
 

--- a/src/PasswordInput/driver.js
+++ b/src/PasswordInput/driver.js
@@ -30,11 +30,6 @@ export default class PasswordInput
             throw new Error( ERR.PASS_ERR( 'blur', 'disabled' ) );
         }
 
-        if ( props.isReadOnly )
-        {
-            throw new Error( ERR.PASS_ERR( 'blur', 'read only' ) );
-        }
-
         this.wrapper.find( InputField ).driver().blur();
         return this;
     }
@@ -46,11 +41,6 @@ export default class PasswordInput
         if ( props.isDisabled )
         {
             throw new Error( ERR.PASS_ERR( 'focus', 'disabled' ) );
-        }
-
-        if ( props.isReadOnly )
-        {
-            throw new Error( ERR.PASS_ERR( 'focus', 'read only' ) );
         }
 
         this.wrapper.find( InputField ).driver().focus();
@@ -66,7 +56,7 @@ export default class PasswordInput
             throw new Error( ERR.PASS_ERR( 'change', 'disabled' ) );
         }
 
-        if ( props.isReadOnly )
+        if ( props.isReadOnly || props.isReadOnlyInput )
         {
             throw new Error( ERR.PASS_ERR( 'change', 'read only' ) );
         }
@@ -84,47 +74,18 @@ export default class PasswordInput
             throw new Error( ERR.PASS_ERR( 'keyPress', 'disabled' ) );
         }
 
-        if ( props.isReadOnly )
-        {
-            throw new Error( ERR.PASS_ERR( 'keyPress', 'read only' ) );
-        }
-
         this.wrapper.find( InputField ).driver().keyPress( keyCode );
         return this;
     }
 
     mouseOver()
     {
-        const props = this.wrapper.props();
-
-        if ( props.isDisabled )
-        {
-            throw new Error( ERR.PASS_ERR( 'mouseOver', 'disabled' ) );
-        }
-
-        if ( props.isReadOnly )
-        {
-            throw new Error( ERR.PASS_ERR( 'mouseOver', 'read only' ) );
-        }
-
         this.wrapper.simulate( 'mouseenter' );
         return this;
     }
 
     mouseOut()
     {
-        const props = this.wrapper.props();
-
-        if ( props.isDisabled )
-        {
-            throw new Error( ERR.PASS_ERR( 'mouseOut', 'disabled' ) );
-        }
-
-        if ( props.isReadOnly )
-        {
-            throw new Error( ERR.PASS_ERR( 'mouseOut', 'read only' ) );
-        }
-
         this.wrapper.simulate( 'mouseleave' );
         return this;
     }
@@ -138,7 +99,7 @@ export default class PasswordInput
             throw new Error( ERR.PASS_ERR( 'clickIcon', 'disabled' ) );
         }
 
-        if ( props.isReadOnly )
+        if ( props.isReadOnly || props.isReadOnlyButton )
         {
             throw new Error( ERR.PASS_ERR( 'clickIcon', 'read only' ) );
         }
@@ -149,40 +110,12 @@ export default class PasswordInput
 
     mouseOverIcon()
     {
-        const props = this.wrapper.props();
-
-        if ( props.isDisabled )
-        {
-            throw new Error( ERR
-                .PASS_ERR( 'mouseOverIcon', 'disabled' ) );
-        }
-
-        if ( props.isReadOnly )
-        {
-            throw new Error( ERR
-                .PASS_ERR( 'mouseOverIcon', 'read only' ) );
-        }
-
         this.wrapper.find( Tooltip ).driver().mouseOver();
         return this;
     }
 
     mouseOutIcon()
     {
-        const props = this.wrapper.props();
-
-        if ( props.isDisabled )
-        {
-            throw new Error( ERR
-                .PASS_ERR( 'mouseOutIcon', 'disabled' ) );
-        }
-
-        if ( props.isReadOnly )
-        {
-            throw new Error( ERR
-                .PASS_ERR( 'mouseOutIcon', 'read only' ) );
-        }
-
         this.wrapper.find( Tooltip ).driver().mouseOut();
         return this;
     }

--- a/src/PasswordInput/driver.js
+++ b/src/PasswordInput/driver.js
@@ -10,8 +10,8 @@
 import { IconButton, InputField, Tooltip } from '../index';
 
 const ERR = {
-    PASS_ERR : ( label, event, state ) => `PasswordInput '${label}' cannot \
-simulate ${event} since it is ${state}`,
+    PASS_ERR : ( event, state ) => `PasswordInput cannot simulate ${event} \
+since it is ${state}`,
 };
 
 export default class PasswordInput
@@ -24,16 +24,15 @@ export default class PasswordInput
     blur()
     {
         const props = this.wrapper.props();
-        const { label } = props;
 
         if ( props.isDisabled )
         {
-            throw new Error( ERR.PASS_ERR( label, 'blur', 'disabled' ) );
+            throw new Error( ERR.PASS_ERR( 'blur', 'disabled' ) );
         }
 
         if ( props.isReadOnly )
         {
-            throw new Error( ERR.PASS_ERR( label, 'blur', 'read only' ) );
+            throw new Error( ERR.PASS_ERR( 'blur', 'read only' ) );
         }
 
         this.wrapper.find( InputField ).driver().blur();
@@ -43,16 +42,15 @@ export default class PasswordInput
     focus()
     {
         const props = this.wrapper.props();
-        const { label } = props;
 
         if ( props.isDisabled )
         {
-            throw new Error( ERR.PASS_ERR( label, 'focus', 'disabled' ) );
+            throw new Error( ERR.PASS_ERR( 'focus', 'disabled' ) );
         }
 
         if ( props.isReadOnly )
         {
-            throw new Error( ERR.PASS_ERR( label, 'focus', 'read only' ) );
+            throw new Error( ERR.PASS_ERR( 'focus', 'read only' ) );
         }
 
         this.wrapper.find( InputField ).driver().focus();
@@ -62,16 +60,15 @@ export default class PasswordInput
     change( val )
     {
         const props = this.wrapper.props();
-        const { label } = props;
 
         if ( props.isDisabled )
         {
-            throw new Error( ERR.PASS_ERR( label, 'change', 'disabled' ) );
+            throw new Error( ERR.PASS_ERR( 'change', 'disabled' ) );
         }
 
         if ( props.isReadOnly )
         {
-            throw new Error( ERR.PASS_ERR( label, 'change', 'read only' ) );
+            throw new Error( ERR.PASS_ERR( 'change', 'read only' ) );
         }
 
         this.wrapper.find( InputField ).driver().change( val );
@@ -81,16 +78,15 @@ export default class PasswordInput
     keyPress()
     {
         const props = this.wrapper.props();
-        const { label } = props;
 
         if ( props.isDisabled )
         {
-            throw new Error( ERR.PASS_ERR( label, 'keyPress', 'disabled' ) );
+            throw new Error( ERR.PASS_ERR( 'keyPress', 'disabled' ) );
         }
 
         if ( props.isReadOnly )
         {
-            throw new Error( ERR.PASS_ERR( label, 'keyPress', 'read only' ) );
+            throw new Error( ERR.PASS_ERR( 'keyPress', 'read only' ) );
         }
 
         this.wrapper.find( InputField ).driver().keyPress();
@@ -100,16 +96,15 @@ export default class PasswordInput
     mouseOver()
     {
         const props = this.wrapper.props();
-        const { label } = props;
 
         if ( props.isDisabled )
         {
-            throw new Error( ERR.PASS_ERR( label, 'mouseOver', 'disabled' ) );
+            throw new Error( ERR.PASS_ERR( 'mouseOver', 'disabled' ) );
         }
 
         if ( props.isReadOnly )
         {
-            throw new Error( ERR.PASS_ERR( label, 'mouseOver', 'read only' ) );
+            throw new Error( ERR.PASS_ERR( 'mouseOver', 'read only' ) );
         }
 
         this.wrapper.simulate( 'mouseenter' );
@@ -119,16 +114,15 @@ export default class PasswordInput
     mouseOut()
     {
         const props = this.wrapper.props();
-        const { label } = props;
 
         if ( props.isDisabled )
         {
-            throw new Error( ERR.PASS_ERR( label, 'mouseOut', 'disabled' ) );
+            throw new Error( ERR.PASS_ERR( 'mouseOut', 'disabled' ) );
         }
 
         if ( props.isReadOnly )
         {
-            throw new Error( ERR.PASS_ERR( label, 'mouseOut', 'read only' ) );
+            throw new Error( ERR.PASS_ERR( 'mouseOut', 'read only' ) );
         }
 
         this.wrapper.simulate( 'mouseleave' );
@@ -138,16 +132,15 @@ export default class PasswordInput
     clickIcon()
     {
         const props = this.wrapper.props();
-        const { label } = props;
 
         if ( props.isDisabled )
         {
-            throw new Error( ERR.PASS_ERR( label, 'clickIcon', 'disabled' ) );
+            throw new Error( ERR.PASS_ERR( 'clickIcon', 'disabled' ) );
         }
 
         if ( props.isReadOnly )
         {
-            throw new Error( ERR.PASS_ERR( label, 'clickIcon', 'read only' ) );
+            throw new Error( ERR.PASS_ERR( 'clickIcon', 'read only' ) );
         }
 
         this.wrapper.find( IconButton ).simulate( 'click' );
@@ -157,18 +150,17 @@ export default class PasswordInput
     mouseOverIcon()
     {
         const props = this.wrapper.props();
-        const { label } = props;
 
         if ( props.isDisabled )
         {
             throw new Error( ERR
-                .PASS_ERR( label, 'mouseOverIcon', 'disabled' ) );
+                .PASS_ERR( 'mouseOverIcon', 'disabled' ) );
         }
 
         if ( props.isReadOnly )
         {
             throw new Error( ERR
-                .PASS_ERR( label, 'mouseOverIcon', 'read only' ) );
+                .PASS_ERR( 'mouseOverIcon', 'read only' ) );
         }
 
         this.wrapper.find( Tooltip ).driver().mouseOver();
@@ -178,18 +170,17 @@ export default class PasswordInput
     mouseOutIcon()
     {
         const props = this.wrapper.props();
-        const { label } = props;
 
         if ( props.isDisabled )
         {
             throw new Error( ERR
-                .PASS_ERR( label, 'mouseOutIcon', 'disabled' ) );
+                .PASS_ERR( 'mouseOutIcon', 'disabled' ) );
         }
 
         if ( props.isReadOnly )
         {
             throw new Error( ERR
-                .PASS_ERR( label, 'mouseOutIcon', 'read only' ) );
+                .PASS_ERR( 'mouseOutIcon', 'read only' ) );
         }
 
         this.wrapper.find( Tooltip ).driver().mouseOut();

--- a/src/PasswordInput/tests.jsx
+++ b/src/PasswordInput/tests.jsx
@@ -123,8 +123,8 @@ describe( 'PasswordInputDriver', () =>
         {
             test( 'throws the expected error when isDisabled', () =>
             {
-                const expectedError = 'PasswordInput \'Cthulhu\' cannot \
-simulate focus since it is disabled';
+                const expectedError = 'PasswordInput cannot simulate focus \
+since it is disabled';
                 wrapper.setProps( { isDisabled: true, label: 'Cthulhu' } );
 
                 expect( () => driver.focus() ).toThrow( expectedError );
@@ -151,8 +151,8 @@ simulate focus since it is disabled';
         {
             test( 'throws the expected error when isReadOnly', () =>
             {
-                const expectedError = 'PasswordInput \'Tekeli-li\' cannot \
-simulate focus since it is read only';
+                const expectedError = 'PasswordInput cannot simulate focus \
+since it is read only';
                 wrapper.setProps( { isReadOnly: true, label: 'Tekeli-li' } );
 
                 expect( () => driver.focus() ).toThrow( expectedError );
@@ -192,8 +192,8 @@ simulate focus since it is read only';
         {
             test( 'throws the expected error when isDisabled', () =>
             {
-                const expectedError = 'PasswordInput \'Cthulhu\' cannot \
-simulate blur since it is disabled';
+                const expectedError = 'PasswordInput cannot simulate blur \
+since it is disabled';
                 wrapper.setProps( { isDisabled: true, label: 'Cthulhu' } );
 
                 expect( () => driver.blur() ).toThrow( expectedError );
@@ -220,8 +220,8 @@ simulate blur since it is disabled';
         {
             test( 'throws the expected error when isReadOnly', () =>
             {
-                const expectedError = 'PasswordInput \'Tekeli-li\' cannot \
-simulate blur since it is read only';
+                const expectedError = 'PasswordInput cannot simulate blur \
+since it is read only';
                 wrapper.setProps( { isReadOnly: true, label: 'Tekeli-li' } );
 
                 expect( () => driver.blur() ).toThrow( expectedError );
@@ -263,8 +263,8 @@ simulate blur since it is read only';
         {
             test( 'throws the expected error when isDisabled', () =>
             {
-                const expectedError = 'PasswordInput \'Cthulhu\' cannot \
-simulate change since it is disabled';
+                const expectedError = 'PasswordInput cannot simulate change \
+since it is disabled';
                 wrapper.setProps( { isDisabled: true, label: 'Cthulhu' } );
 
                 expect( () => driver.change( 'Azathoth' ) )
@@ -292,8 +292,8 @@ simulate change since it is disabled';
         {
             test( 'throws the expected error when isReadOnly', () =>
             {
-                const expectedError = 'PasswordInput \'Tekeli-li\' cannot \
-simulate change since it is read only';
+                const expectedError = 'PasswordInput cannot simulate change \
+since it is read only';
                 wrapper.setProps( { isReadOnly: true, label: 'Tekeli-li' } );
 
                 expect( () => driver.change( 'Azathoth' ) )
@@ -334,8 +334,8 @@ simulate change since it is read only';
         {
             test( 'throws the expected error when isDisabled', () =>
             {
-                const expectedError = 'PasswordInput \'Cthulhu\' cannot \
-simulate keyPress since it is disabled';
+                const expectedError = 'PasswordInput cannot simulate keyPress \
+since it is disabled';
                 wrapper.setProps( { isDisabled: true, label: 'Cthulhu' } );
 
                 expect( () => driver.keyPress() ).toThrow( expectedError );
@@ -362,8 +362,8 @@ simulate keyPress since it is disabled';
         {
             test( 'throws the expected error when isReadOnly', () =>
             {
-                const expectedError = 'PasswordInput \'Tekeli-li\' cannot \
-simulate keyPress since it is read only';
+                const expectedError = 'PasswordInput cannot simulate keyPress \
+since it is read only';
                 wrapper.setProps( { isReadOnly: true, label: 'Tekeli-li' } );
 
                 expect( () => driver.keyPress() ).toThrow( expectedError );
@@ -403,8 +403,8 @@ simulate keyPress since it is read only';
         {
             test( 'throws the expected error when isDisabled', () =>
             {
-                const expectedError = 'PasswordInput \'Cthulhu\' cannot \
-simulate mouseOver since it is disabled';
+                const expectedError = 'PasswordInput cannot simulate mouseOver \
+since it is disabled';
                 wrapper.setProps( { isDisabled: true, label: 'Cthulhu' } );
 
                 expect( () => driver.mouseOver() ).toThrow( expectedError );
@@ -431,8 +431,8 @@ simulate mouseOver since it is disabled';
         {
             test( 'throws the expected error when isReadOnly', () =>
             {
-                const expectedError = 'PasswordInput \'Tekeli-li\' cannot \
-simulate mouseOver since it is read only';
+                const expectedError = 'PasswordInput cannot simulate mouseOver \
+since it is read only';
                 wrapper.setProps( { isReadOnly: true, label: 'Tekeli-li' } );
 
                 expect( () => driver.mouseOver() ).toThrow( expectedError );
@@ -472,8 +472,8 @@ simulate mouseOver since it is read only';
         {
             test( 'throws the expected error when isDisabled', () =>
             {
-                const expectedError = 'PasswordInput \'Cthulhu\' cannot \
-simulate mouseOut since it is disabled';
+                const expectedError = 'PasswordInput cannot simulate mouseOut \
+since it is disabled';
                 wrapper.setProps( { isDisabled: true, label: 'Cthulhu' } );
 
                 expect( () => driver.mouseOut() ).toThrow( expectedError );
@@ -500,8 +500,8 @@ simulate mouseOut since it is disabled';
         {
             test( 'throws the expected error when isReadOnly', () =>
             {
-                const expectedError = 'PasswordInput \'Tekeli-li\' cannot \
-simulate mouseOut since it is read only';
+                const expectedError = 'PasswordInput cannot simulate mouseOut \
+since it is read only';
                 wrapper.setProps( { isReadOnly: true, label: 'Tekeli-li' } );
 
                 expect( () => driver.mouseOut() ).toThrow( expectedError );
@@ -543,8 +543,8 @@ simulate mouseOut since it is read only';
         {
             test( 'throws the expected error when isDisabled', () =>
             {
-                const expectedError = 'PasswordInput \'Cthulhu\' cannot \
-simulate clickIcon since it is disabled';
+                const expectedError = 'PasswordInput cannot simulate clickIcon \
+since it is disabled';
                 wrapper.setProps( { isDisabled: true, label: 'Cthulhu' } );
 
                 expect( () => driver.clickIcon() ).toThrow( expectedError );
@@ -571,8 +571,8 @@ simulate clickIcon since it is disabled';
         {
             test( 'throws the expected error when isReadOnly', () =>
             {
-                const expectedError = 'PasswordInput \'Tekeli-li\' cannot \
-simulate clickIcon since it is read only';
+                const expectedError = 'PasswordInput cannot simulate clickIcon \
+since it is read only';
                 wrapper.setProps( { isReadOnly: true, label: 'Tekeli-li' } );
 
                 expect( () => driver.clickIcon() ).toThrow( expectedError );
@@ -612,8 +612,8 @@ simulate clickIcon since it is read only';
         {
             test( 'throws the expected error when isDisabled', () =>
             {
-                const expectedError = 'PasswordInput \'Cthulhu\' cannot \
-simulate mouseOverIcon since it is disabled';
+                const expectedError = 'PasswordInput cannot simulate \
+mouseOverIcon since it is disabled';
                 wrapper.setProps( { isDisabled: true, label: 'Cthulhu' } );
 
                 expect( () => driver.mouseOverIcon() ).toThrow( expectedError );
@@ -640,8 +640,8 @@ simulate mouseOverIcon since it is disabled';
         {
             test( 'throws the expected error when isReadOnly', () =>
             {
-                const expectedError = 'PasswordInput \'Tekeli-li\' cannot \
-simulate mouseOverIcon since it is read only';
+                const expectedError = 'PasswordInput cannot simulate \
+mouseOverIcon since it is read only';
                 wrapper.setProps( { isReadOnly: true, label: 'Tekeli-li' } );
 
                 expect( () => driver.mouseOverIcon() ).toThrow( expectedError );
@@ -681,8 +681,8 @@ simulate mouseOverIcon since it is read only';
         {
             test( 'throws the expected error when isDisabled', () =>
             {
-                const expectedError = 'PasswordInput \'Cthulhu\' cannot \
-simulate mouseOutIcon since it is disabled';
+                const expectedError = 'PasswordInput cannot simulate \
+mouseOutIcon since it is disabled';
                 wrapper.setProps( { isDisabled: true, label: 'Cthulhu' } );
 
                 expect( () => driver.mouseOutIcon() ).toThrow( expectedError );
@@ -709,8 +709,8 @@ simulate mouseOutIcon since it is disabled';
         {
             test( 'throws the expected error when isReadOnly', () =>
             {
-                const expectedError = 'PasswordInput \'Tekeli-li\' cannot \
-simulate mouseOutIcon since it is read only';
+                const expectedError = 'PasswordInput cannot simulate \
+mouseOutIcon since it is read only';
                 wrapper.setProps( { isReadOnly: true, label: 'Tekeli-li' } );
 
                 expect( () => driver.mouseOutIcon() ).toThrow( expectedError );

--- a/src/PasswordInput/tests.jsx
+++ b/src/PasswordInput/tests.jsx
@@ -145,34 +145,6 @@ since it is disabled';
                 }
             } );
         } );
-
-
-        describe( 'isReadOnly', () =>
-        {
-            test( 'throws the expected error when isReadOnly', () =>
-            {
-                const expectedError = 'PasswordInput cannot simulate focus \
-since it is read only';
-                wrapper.setProps( { isReadOnly: true, label: 'Tekeli-li' } );
-
-                expect( () => driver.focus() ).toThrow( expectedError );
-            } );
-
-            test( 'should not trigger onFocus when isReadOnly', () =>
-            {
-                const onFocus = jest.fn();
-                wrapper.setProps( { onFocus, isReadOnly: true } );
-
-                try
-                {
-                    driver.focus();
-                }
-                catch ( error )
-                {
-                    expect( onFocus ).not.toBeCalled();
-                }
-            } );
-        } );
     } );
 
 
@@ -214,34 +186,6 @@ since it is disabled';
                 }
             } );
         } );
-
-
-        describe( 'isReadOnly', () =>
-        {
-            test( 'throws the expected error when isReadOnly', () =>
-            {
-                const expectedError = 'PasswordInput cannot simulate blur \
-since it is read only';
-                wrapper.setProps( { isReadOnly: true, label: 'Tekeli-li' } );
-
-                expect( () => driver.blur() ).toThrow( expectedError );
-            } );
-
-            test( 'should not trigger onBlur when isReadOnly', () =>
-            {
-                const onBlur = jest.fn();
-                wrapper.setProps( { onBlur, isReadOnly: true } );
-
-                try
-                {
-                    driver.blur();
-                }
-                catch ( error )
-                {
-                    expect( onBlur ).not.toBeCalled();
-                }
-            } );
-        } );
     } );
 
 
@@ -249,13 +193,13 @@ since it is read only';
     {
         test( 'should fire the onChange callback prop once', () =>
         {
-            const changeSpy = jest.fn();
+            const onChange = jest.fn();
             wrapper.setProps( {
-                onChange : changeSpy,
+                onChange,
             } );
 
             driver.change( 'Azathoth' );
-            expect( changeSpy ).toBeCalledTimes( 1 );
+            expect( onChange ).toBeCalledTimes( 1 );
         } );
 
 
@@ -356,34 +300,6 @@ since it is disabled';
                 }
             } );
         } );
-
-
-        describe( 'isReadOnly', () =>
-        {
-            test( 'throws the expected error when isReadOnly', () =>
-            {
-                const expectedError = 'PasswordInput cannot simulate keyPress \
-since it is read only';
-                wrapper.setProps( { isReadOnly: true, label: 'Tekeli-li' } );
-
-                expect( () => driver.keyPress() ).toThrow( expectedError );
-            } );
-
-            test( 'should not trigger onKeyPress when isReadOnly', () =>
-            {
-                const onKeyPress = jest.fn();
-                wrapper.setProps( { onKeyPress, isReadOnly: true } );
-
-                try
-                {
-                    driver.keyPress();
-                }
-                catch ( error )
-                {
-                    expect( onKeyPress ).not.toBeCalled();
-                }
-            } );
-        } );
     } );
 
 
@@ -397,62 +313,6 @@ since it is read only';
             driver.mouseOver();
             expect( onMouseOver ).toBeCalledTimes( 1 );
         } );
-
-
-        describe( 'isDisabled', () =>
-        {
-            test( 'throws the expected error when isDisabled', () =>
-            {
-                const expectedError = 'PasswordInput cannot simulate mouseOver \
-since it is disabled';
-                wrapper.setProps( { isDisabled: true, label: 'Cthulhu' } );
-
-                expect( () => driver.mouseOver() ).toThrow( expectedError );
-            } );
-
-            test( 'should not trigger onMouseOver when isDisabled', () =>
-            {
-                const onMouseOver = jest.fn();
-                wrapper.setProps( { onMouseOver, isDisabled: true } );
-
-                try
-                {
-                    driver.mouseOver();
-                }
-                catch ( error )
-                {
-                    expect( onMouseOver ).not.toBeCalled();
-                }
-            } );
-        } );
-
-
-        describe( 'isReadOnly', () =>
-        {
-            test( 'throws the expected error when isReadOnly', () =>
-            {
-                const expectedError = 'PasswordInput cannot simulate mouseOver \
-since it is read only';
-                wrapper.setProps( { isReadOnly: true, label: 'Tekeli-li' } );
-
-                expect( () => driver.mouseOver() ).toThrow( expectedError );
-            } );
-
-            test( 'should not trigger onMouseOver when isReadOnly', () =>
-            {
-                const onMouseOver = jest.fn();
-                wrapper.setProps( { onMouseOver, isReadOnly: true } );
-
-                try
-                {
-                    driver.mouseOver();
-                }
-                catch ( error )
-                {
-                    expect( onMouseOver ).not.toBeCalled();
-                }
-            } );
-        } );
     } );
 
 
@@ -465,62 +325,6 @@ since it is read only';
 
             driver.mouseOut();
             expect( onMouseOut ).toBeCalledTimes( 1 );
-        } );
-
-
-        describe( 'isDisabled', () =>
-        {
-            test( 'throws the expected error when isDisabled', () =>
-            {
-                const expectedError = 'PasswordInput cannot simulate mouseOut \
-since it is disabled';
-                wrapper.setProps( { isDisabled: true, label: 'Cthulhu' } );
-
-                expect( () => driver.mouseOut() ).toThrow( expectedError );
-            } );
-
-            test( 'should not trigger onMouseOut when isDisabled', () =>
-            {
-                const onMouseOut = jest.fn();
-                wrapper.setProps( { onMouseOut, isDisabled: true } );
-
-                try
-                {
-                    driver.mouseOut();
-                }
-                catch ( error )
-                {
-                    expect( onMouseOut ).not.toBeCalled();
-                }
-            } );
-        } );
-
-
-        describe( 'isReadOnly', () =>
-        {
-            test( 'throws the expected error when isReadOnly', () =>
-            {
-                const expectedError = 'PasswordInput cannot simulate mouseOut \
-since it is read only';
-                wrapper.setProps( { isReadOnly: true, label: 'Tekeli-li' } );
-
-                expect( () => driver.mouseOut() ).toThrow( expectedError );
-            } );
-
-            test( 'should not trigger onMouseOut when isReadOnly', () =>
-            {
-                const onMouseOut = jest.fn();
-                wrapper.setProps( { onMouseOut, isReadOnly: true } );
-
-                try
-                {
-                    driver.mouseOut();
-                }
-                catch ( error )
-                {
-                    expect( onMouseOut ).not.toBeCalled();
-                }
-            } );
         } );
     } );
 
@@ -606,62 +410,6 @@ since it is read only';
             driver.mouseOverIcon();
             expect( onMouseOverIcon ).toBeCalledTimes( 1 );
         } );
-
-
-        describe( 'isDisabled', () =>
-        {
-            test( 'throws the expected error when isDisabled', () =>
-            {
-                const expectedError = 'PasswordInput cannot simulate \
-mouseOverIcon since it is disabled';
-                wrapper.setProps( { isDisabled: true, label: 'Cthulhu' } );
-
-                expect( () => driver.mouseOverIcon() ).toThrow( expectedError );
-            } );
-
-            test( 'should not trigger onMouseOverIcon when isDisabled', () =>
-            {
-                const onMouseOverIcon = jest.fn();
-                wrapper.setProps( { onMouseOverIcon, isDisabled: true } );
-
-                try
-                {
-                    driver.mouseOverIcon();
-                }
-                catch ( error )
-                {
-                    expect( onMouseOverIcon ).not.toBeCalled();
-                }
-            } );
-        } );
-
-
-        describe( 'isReadOnly', () =>
-        {
-            test( 'throws the expected error when isReadOnly', () =>
-            {
-                const expectedError = 'PasswordInput cannot simulate \
-mouseOverIcon since it is read only';
-                wrapper.setProps( { isReadOnly: true, label: 'Tekeli-li' } );
-
-                expect( () => driver.mouseOverIcon() ).toThrow( expectedError );
-            } );
-
-            test( 'should not trigger onMouseOverIcon when isReadOnly', () =>
-            {
-                const onMouseOverIcon = jest.fn();
-                wrapper.setProps( { onMouseOverIcon, isReadOnly: true } );
-
-                try
-                {
-                    driver.mouseOverIcon();
-                }
-                catch ( error )
-                {
-                    expect( onMouseOverIcon ).not.toBeCalled();
-                }
-            } );
-        } );
     } );
 
 
@@ -674,62 +422,6 @@ mouseOverIcon since it is read only';
 
             driver.mouseOutIcon();
             expect( onMouseOutIcon ).toBeCalledTimes( 1 );
-        } );
-
-
-        describe( 'isDisabled', () =>
-        {
-            test( 'throws the expected error when isDisabled', () =>
-            {
-                const expectedError = 'PasswordInput cannot simulate \
-mouseOutIcon since it is disabled';
-                wrapper.setProps( { isDisabled: true, label: 'Cthulhu' } );
-
-                expect( () => driver.mouseOutIcon() ).toThrow( expectedError );
-            } );
-
-            test( 'should not trigger onMouseOutIcon when isDisabled', () =>
-            {
-                const onMouseOutIcon = jest.fn();
-                wrapper.setProps( { onMouseOutIcon, isDisabled: true } );
-
-                try
-                {
-                    driver.mouseOutIcon();
-                }
-                catch ( error )
-                {
-                    expect( onMouseOutIcon ).not.toBeCalled();
-                }
-            } );
-        } );
-
-
-        describe( 'isReadOnly', () =>
-        {
-            test( 'throws the expected error when isReadOnly', () =>
-            {
-                const expectedError = 'PasswordInput cannot simulate \
-mouseOutIcon since it is read only';
-                wrapper.setProps( { isReadOnly: true, label: 'Tekeli-li' } );
-
-                expect( () => driver.mouseOutIcon() ).toThrow( expectedError );
-            } );
-
-            test( 'should not trigger onMouseOutIcon when isReadOnly', () =>
-            {
-                const onMouseOutIcon = jest.fn();
-                wrapper.setProps( { onMouseOutIcon, isReadOnly: true } );
-
-                try
-                {
-                    driver.mouseOutIcon();
-                }
-                catch ( error )
-                {
-                    expect( onMouseOutIcon ).not.toBeCalled();
-                }
-            } );
         } );
     } );
 } );

--- a/src/Radio/driver.js
+++ b/src/Radio/driver.js
@@ -14,8 +14,9 @@ export default class RadioDriver
 
     blur()
     {
-        const props     = this.wrapper.props();
-        const { label } = props;
+        const props = this.wrapper.props();
+        const label = this.wrapper.find( `.${props.cssMap.labelContent}` )
+            .text();
 
         if ( props.isDisabled )
         {
@@ -33,8 +34,9 @@ export default class RadioDriver
 
     focus()
     {
-        const props     = this.wrapper.props();
-        const { label } = props;
+        const props = this.wrapper.props();
+        const label = this.wrapper.find( `.${props.cssMap.labelContent}` )
+            .text();
 
         if ( props.isDisabled )
         {
@@ -52,9 +54,10 @@ export default class RadioDriver
 
     change()
     {
-        const props     = this.wrapper.props();
-        const { label } = props;
-        const node      = this.control.getNode();
+        const props = this.wrapper.props();
+        const label = this.wrapper.find( `.${props.cssMap.labelContent}` )
+            .text();
+        const node  = this.control.getNode();
 
         if ( props.isDisabled )
         {
@@ -78,8 +81,9 @@ export default class RadioDriver
 
     click()
     {
-        const props     = this.wrapper.props();
-        const { label } = props;
+        const props = this.wrapper.props();
+        const label = this.wrapper.find( `.${props.cssMap.labelContent}` )
+            .text();
 
         if ( props.isDisabled )
         {
@@ -97,8 +101,9 @@ export default class RadioDriver
 
     mouseOver()
     {
-        const props     = this.wrapper.props();
-        const { label } = props;
+        const props = this.wrapper.props();
+        const label = this.wrapper.find( `.${props.cssMap.labelContent}` )
+            .text();
 
         if ( props.isDisabled )
         {
@@ -111,8 +116,9 @@ export default class RadioDriver
 
     mouseOut()
     {
-        const props     = this.wrapper.props();
-        const { label } = props;
+        const props = this.wrapper.props();
+        const label = this.wrapper.find( `.${props.cssMap.labelContent}` )
+            .text();
 
         if ( props.isDisabled )
         {

--- a/src/Radio/driver.js
+++ b/src/Radio/driver.js
@@ -8,8 +8,7 @@ export default class RadioDriver
     constructor( wrapper )
     {
         this.wrapper = wrapper;
-        this.control = wrapper
-            .find( `.${this.wrapper.props().cssMap.input}` );
+        this.control = wrapper.find( `.${this.wrapper.props().cssMap.input}` );
     }
 
     blur()
@@ -101,30 +100,12 @@ export default class RadioDriver
 
     mouseOver()
     {
-        const props = this.wrapper.props();
-        const label = this.wrapper.find( `.${props.cssMap.labelContent}` )
-            .text();
-
-        if ( props.isDisabled )
-        {
-            throw new Error( ERR.RADIO_ERR( label, 'mouseOver', 'disabled' ) );
-        }
-
         this.wrapper.simulate( 'mouseenter' );
         return this;
     }
 
     mouseOut()
     {
-        const props = this.wrapper.props();
-        const label = this.wrapper.find( `.${props.cssMap.labelContent}` )
-            .text();
-
-        if ( props.isDisabled )
-        {
-            throw new Error( ERR.RADIO_ERR( label, 'mouseOut', 'disabled' ) );
-        }
-
         this.wrapper.simulate( 'mouseleave' );
         return this;
     }

--- a/src/Radio/tests.jsx
+++ b/src/Radio/tests.jsx
@@ -128,7 +128,6 @@ describe( 'RadioDriver', () =>
             wrapper.setProps( { onBlur } );
 
             driver.blur();
-
             expect( onBlur ).toBeCalledTimes( 1 );
         } );
 
@@ -137,10 +136,9 @@ describe( 'RadioDriver', () =>
         {
             test( 'throws the expected error when isDisabled', () =>
             {
-                wrapper.setProps( { isDisabled: true, label: 'Tekeli-li' } );
-
                 const expectedError = 'Radio \'Tekeli-li\' cannot simulate \
 blur since it is disabled';
+                wrapper.setProps( { isDisabled: true, label: 'Tekeli-li' } );
 
                 expect( () => driver.blur() ).toThrow( expectedError );
             } );
@@ -170,10 +168,9 @@ blur since it is disabled';
         {
             test( 'throws the expected error when isReadOnly', () =>
             {
-                wrapper.setProps( { isReadOnly: true, label: 'Tekeli-li' } );
-
                 const expectedError = 'Radio \'Tekeli-li\' cannot simulate \
 blur since it is read only';
+                wrapper.setProps( { isReadOnly: true, label: 'Tekeli-li' } );
 
                 expect( () => driver.blur() ).toThrow( expectedError );
             } );
@@ -208,7 +205,6 @@ blur since it is read only';
             wrapper.setProps( { onFocus } );
 
             driver.focus();
-
             expect( onFocus ).toBeCalledTimes( 1 );
         } );
 
@@ -217,10 +213,9 @@ blur since it is read only';
         {
             test( 'throws the expected error when isDisabled', () =>
             {
-                wrapper.setProps( { isDisabled: true, label: 'Tekeli-li' } );
-
                 const expectedError = 'Radio \'Tekeli-li\' cannot simulate \
 focus since it is disabled';
+                wrapper.setProps( { isDisabled: true, label: 'Tekeli-li' } );
 
                 expect( () => driver.focus() ).toThrow( expectedError );
             } );
@@ -250,10 +245,9 @@ focus since it is disabled';
         {
             test( 'throws the expected error when isReadOnly', () =>
             {
-                wrapper.setProps( { isReadOnly: true, label: 'Tekeli-li' } );
-
                 const expectedError = 'Radio \'Tekeli-li\' cannot simulate \
 focus since it is read only';
+                wrapper.setProps( { isReadOnly: true, label: 'Tekeli-li' } );
 
                 expect( () => driver.focus() ).toThrow( expectedError );
             } );
@@ -288,7 +282,6 @@ focus since it is read only';
             wrapper.setProps( { onChange } );
 
             driver.change();
-
             expect( onChange ).toBeCalledTimes( 1 );
         } );
 
@@ -317,10 +310,9 @@ focus since it is read only';
         {
             test( 'throws the expected error when isDisabled', () =>
             {
-                wrapper.setProps( { isDisabled: true, label: 'Tekeli-li' } );
-
                 const expectedError = 'Radio \'Tekeli-li\' cannot simulate \
 change since it is disabled';
+                wrapper.setProps( { isDisabled: true, label: 'Tekeli-li' } );
 
                 expect( () => driver.change() ).toThrow( expectedError );
             } );
@@ -350,10 +342,9 @@ change since it is disabled';
         {
             test( 'throws the expected error when isReadOnly', () =>
             {
-                wrapper.setProps( { isReadOnly: true, label: 'Tekeli-li' } );
-
                 const expectedError = 'Radio \'Tekeli-li\' cannot simulate \
 change since it is read only';
+                wrapper.setProps( { isReadOnly: true, label: 'Tekeli-li' } );
 
                 expect( () => driver.change() ).toThrow( expectedError );
             } );
@@ -361,7 +352,6 @@ change since it is read only';
             test( 'should not trigger onChange when isReadOnly', () =>
             {
                 const onChange = jest.fn();
-
                 wrapper.setProps( {
                     isReadOnly : true,
                     label      : 'Tekeli-li',
@@ -386,10 +376,9 @@ change since it is read only';
         test( 'should call onClick once', () =>
         {
             const onClick = jest.fn();
-
             wrapper.setProps( { onClick } );
-            driver.click();
 
+            driver.click();
             expect( onClick ).toBeCalledTimes( 1 );
         } );
 
@@ -398,10 +387,9 @@ change since it is read only';
         {
             test( 'throws the expected error when isDisabled', () =>
             {
-                wrapper.setProps( { isDisabled: true, label: 'Tekeli-li' } );
-
                 const expectedError = 'Radio \'Tekeli-li\' cannot simulate \
 click since it is disabled';
+                wrapper.setProps( { isDisabled: true, label: 'Tekeli-li' } );
 
                 expect( () => driver.click() ).toThrow( expectedError );
             } );
@@ -431,10 +419,9 @@ click since it is disabled';
         {
             test( 'throws the expected error when isReadOnly', () =>
             {
-                wrapper.setProps( { isReadOnly: true, label: 'Tekeli-li' } );
-
                 const expectedError = 'Radio \'Tekeli-li\' cannot simulate \
 click since it is read only';
+                wrapper.setProps( { isReadOnly: true, label: 'Tekeli-li' } );
 
                 expect( () => driver.click() ).toThrow( expectedError );
             } );
@@ -442,7 +429,6 @@ click since it is read only';
             test( 'should not trigger onClick when isReadOnly', () =>
             {
                 const onClick = jest.fn();
-
                 wrapper.setProps( {
                     isReadOnly : true,
                     label      : 'Tekeli-li',
@@ -470,31 +456,7 @@ click since it is read only';
             wrapper.setProps( { onMouseOver } );
 
             driver.mouseOver();
-
             expect( onMouseOver ).toBeCalledTimes( 1 );
-        } );
-
-        test( 'throws the expected error when isDisabled', () =>
-        {
-            wrapper.setProps( { isDisabled: true, label: 'Tekeli-li' } );
-
-            const expectedError = 'Radio \'Tekeli-li\' cannot simulate \
-mouseOut since it is disabled';
-
-            expect( () => driver.mouseOut() ).toThrow( expectedError );
-        } );
-
-        test( 'should not trigger onMouseOver when isDisabled', () =>
-        {
-            const onMouseOver = jest.fn();
-            wrapper.setProps( {
-                isDisabled : true,
-                label      : 'Tekeli-li',
-                onMouseOver,
-            } );
-
-            expect( () => driver.mouseOut() );
-            expect( onMouseOver ).not.toBeCalled();
         } );
     } );
 
@@ -507,35 +469,7 @@ mouseOut since it is disabled';
             wrapper.setProps( { onMouseOut } );
 
             driver.mouseOut();
-
             expect( onMouseOut ).toBeCalledTimes( 1 );
-        } );
-
-
-        describe( 'isDisabled', () =>
-        {
-            test( 'throws the expected error when isDisabled', () =>
-            {
-                wrapper.setProps( { isDisabled: true, label: 'Tekeli-li' } );
-
-                const expectedError = 'Radio \'Tekeli-li\' cannot simulate \
-mouseOut since it is disabled';
-
-                expect( () => driver.mouseOut() ).toThrow( expectedError );
-            } );
-
-            test( 'should not trigger onMouseOut when isDisabled', () =>
-            {
-                const onMouseOut = jest.fn();
-                wrapper.setProps( {
-                    isDisabled : true,
-                    label      : 'Tekeli-li',
-                    onMouseOut,
-                } );
-
-                expect( () => driver.mouseOut() );
-                expect( onMouseOut ).not.toBeCalled();
-            } );
         } );
     } );
 } );

--- a/src/RadioGroup/driver.js
+++ b/src/RadioGroup/driver.js
@@ -14,7 +14,6 @@ export default class RadioGroupDriver
     constructor( wrapper )
     {
         this.wrapper    = wrapper;
-        this.cssMap     = wrapper.props().cssMap;
         this.checkables = wrapper.find( CheckableGroup );
     }
 

--- a/src/ScrollBox/driver.js
+++ b/src/ScrollBox/driver.js
@@ -80,13 +80,14 @@ export default class ScrollBoxDriver
 
     scrollVertical( scrollOffset = 0 )
     {
+        const node = this.scrollBox.getNode();
+
         if ( !( this.props.scroll === 'vertical' ||
             this.props.scroll === 'both' ) )
         {
             throw new Error( ERR.CANNOT_SCROLL_IN_DIRECTION( 'vertical' ) );
         }
 
-        const node     = this.scrollBox.getNode();
         node.scrollTop = scrollOffset;
         this.scrollBox.simulate( 'scroll' );
 
@@ -95,6 +96,8 @@ export default class ScrollBoxDriver
 
     scrollHorizontal( scrollOffset = 0 )
     {
+        const node = this.scrollBox.getNode();
+
         if ( !( this.props.scroll === 'horizontal' ||
             this.props.scroll === 'both' ) )
         {
@@ -102,7 +105,6 @@ export default class ScrollBoxDriver
                 .CANNOT_SCROLL_IN_DIRECTION( 'horizontal' ) );
         }
 
-        const node      = this.scrollBox.getNode();
         node.scrollLeft = scrollOffset;
         this.scrollBox.simulate( 'scroll' );
 
@@ -111,33 +113,38 @@ export default class ScrollBoxDriver
 
     seekVertical( scrollOffset )
     {
+        const node      = this.scrollBox.getNode();
+        const scrollBar = this.wrapper.find( ScrollBar ).last();
+
         if ( !( this.props.scroll === 'vertical' ||
             this.props.scroll === 'both' ) )
         {
             throw new Error( ERR.CANNOT_SCROLL_IN_DIRECTION( 'vertical' ) );
         }
 
-        const node     = this.scrollBox.getNode();
-        const scrollBar = this.wrapper.find( ScrollBar ).last();
         node.scrollTop = scrollOffset;
         this.scrollBox.simulate( 'scroll' );
         scrollBar.driver().change( scrollOffset );
+
         return this;
     }
 
     seekHorizontal( scrollOffset )
     {
+        const node      = this.scrollBox.getNode();
+        const scrollBar = this.wrapper.find( ScrollBar ).first();
+
         if ( !( this.props.scroll === 'vertical' ||
             this.props.scroll === 'both' ) )
         {
             throw new Error( ERR.CANNOT_SCROLL_IN_DIRECTION( 'vertical' ) );
         }
 
-        const node     = this.scrollBox.getNode();
-        const scrollBar = this.wrapper.find( ScrollBar ).first();
+
         node.scrollLeft = scrollOffset;
         this.scrollBox.simulate( 'scroll' );
         scrollBar.driver().change( scrollOffset );
+
         return this;
     }
 }

--- a/src/Switch/driver.js
+++ b/src/Switch/driver.js
@@ -18,7 +18,7 @@ export default class SwitchDriver
     {
         this.wrapper = wrapper;
         this.cssMap  = wrapper.props().cssMap;
-        this.input = wrapper.find( `.${wrapper.props().cssMap.input}` );
+        this.input   = wrapper.find( `.${wrapper.props().cssMap.input}` );
     }
 
     change()

--- a/src/Switch/driver.js
+++ b/src/Switch/driver.js
@@ -24,6 +24,7 @@ export default class SwitchDriver
     change()
     {
         const props = this.wrapper.props();
+        const node  = this.input.getNode();
 
         if ( props.isDisabled )
         {
@@ -34,8 +35,6 @@ export default class SwitchDriver
         {
             throw new Error( ERR.SWITCH_ERR( 'change', 'read only' ) );
         }
-
-        const node = this.input.getNode();
 
         node.checked = !node.checked;
         this.input.simulate( 'change' );

--- a/src/TagInput/driver.js
+++ b/src/TagInput/driver.js
@@ -46,11 +46,6 @@ export default class TagInputDriver
             throw new Error( ERR.TAGINPUT_ERR( 'blur', 'disabled' ) );
         }
 
-        if ( this.wrapper.props().isReadOnly )
-        {
-            throw new Error( ERR.TAGINPUT_ERR( 'blur', 'read only' ) );
-        }
-
         this.wrapper.find( `.${this.wrapper.props().cssMap.input}` )
             .simulate( 'blur' );
         return this;
@@ -80,11 +75,6 @@ export default class TagInputDriver
             throw new Error( ERR.TAGINPUT_ERR( 'focus', 'disabled' ) );
         }
 
-        if ( this.wrapper.props().isReadOnly )
-        {
-            throw new Error( ERR.TAGINPUT_ERR( 'focus', 'read only' ) );
-        }
-
         this.wrapper.find( `.${this.wrapper.props().cssMap.input}` )
             .simulate( 'focus' );
         return this;
@@ -95,11 +85,6 @@ export default class TagInputDriver
         if ( this.wrapper.props().isDisabled )
         {
             throw new Error( ERR.TAGINPUT_ERR( 'keyPress', 'disabled' ) );
-        }
-
-        if ( this.wrapper.props().isReadOnly )
-        {
-            throw new Error( ERR.TAGINPUT_ERR( 'keyPress', 'read only' ) );
         }
 
         this.wrapper.find( `.${this.wrapper.props().cssMap.input}` )
@@ -114,11 +99,6 @@ export default class TagInputDriver
             throw new Error( ERR.TAGINPUT_ERR( 'keyDown', 'disabled' ) );
         }
 
-        if ( this.wrapper.props().isReadOnly )
-        {
-            throw new Error( ERR.TAGINPUT_ERR( 'keyDown', 'read only' ) );
-        }
-
         this.wrapper.find( `.${this.wrapper.props().cssMap.input}` )
             .simulate( 'keyDown', { keyCode } );
         return this;
@@ -131,11 +111,6 @@ export default class TagInputDriver
             throw new Error( ERR.TAGINPUT_ERR( 'keyUp', 'disabled' ) );
         }
 
-        if ( this.wrapper.props().isReadOnly )
-        {
-            throw new Error( ERR.TAGINPUT_ERR( 'keyUp', 'read only' ) );
-        }
-
         this.wrapper.find( `.${this.wrapper.props().cssMap.input}` )
             .simulate( 'keyUp', { keyCode } );
         return this;
@@ -143,22 +118,12 @@ export default class TagInputDriver
 
     mouseOver()
     {
-        if ( this.wrapper.props().isDisabled )
-        {
-            throw new Error( ERR.TAGINPUT_ERR( 'mouseOver', 'disabled' ) );
-        }
-
         this.wrapper.simulate( 'mouseenter' );
         return this;
     }
 
     mouseOut()
     {
-        if ( this.wrapper.props().isDisabled )
-        {
-            throw new Error( ERR.TAGINPUT_ERR( 'mouseOut', 'disabled' ) );
-        }
-
         this.wrapper.simulate( 'mouseleave' );
         return this;
     }

--- a/src/TagInput/tests.jsx
+++ b/src/TagInput/tests.jsx
@@ -153,34 +153,6 @@ describe( 'TagInputDriver', () =>
                 }
             } );
         } );
-
-
-        describe( 'isReadOnly', () =>
-        {
-            test( 'throws the expected error when isReadOnly', () =>
-            {
-                const expectedError =
-                    'TagInput cannot simulate blur since it is read only';
-                wrapper.setProps( { isReadOnly: true } );
-
-                expect( () => driver.blur() ).toThrow( expectedError );
-            } );
-
-            test( 'should not trigger onBlur when isReadOnly', () =>
-            {
-                const onBlur = jest.fn();
-                wrapper.setProps( { onBlur, isReadOnly: true } );
-
-                try
-                {
-                    driver.blur();
-                }
-                catch ( error )
-                {
-                    expect( onBlur ).not.toBeCalled();
-                }
-            } );
-        } );
     } );
 
 
@@ -217,34 +189,6 @@ describe( 'TagInputDriver', () =>
             {
                 const onFocus = jest.fn();
                 wrapper.setProps( { onFocus, isDisabled: true } );
-
-                try
-                {
-                    driver.focus();
-                }
-                catch ( error )
-                {
-                    expect( onFocus ).not.toBeCalled();
-                }
-            } );
-        } );
-
-
-        describe( 'isReadOnly', () =>
-        {
-            test( 'throws the expected error when isReadOnly', () =>
-            {
-                const expectedError =
-                    'TagInput cannot simulate focus since it is read only';
-                wrapper.setProps( { isReadOnly: true } );
-
-                expect( () => driver.focus() ).toThrow( expectedError );
-            } );
-
-            test( 'should not trigger onFocus when isReadOnly', () =>
-            {
-                const onFocus = jest.fn();
-                wrapper.setProps( { onFocus, isReadOnly: true } );
 
                 try
                 {
@@ -455,34 +399,6 @@ describe( 'TagInputDriver', () =>
                 }
             } );
         } );
-
-
-        describe( 'isReadOnly', () =>
-        {
-            test( 'throws the expected error when isReadOnly', () =>
-            {
-                const expectedError =
-                    'TagInput cannot simulate keyPress since it is read only';
-                wrapper.setProps( { isReadOnly: true } );
-
-                expect( () => driver.keyPress() ).toThrow( expectedError );
-            } );
-
-            test( 'should not trigger onKeyPress when isReadOnly', () =>
-            {
-                const onKeyPress = jest.fn();
-                wrapper.setProps( { onKeyPress, isReadOnly: true } );
-
-                try
-                {
-                    driver.keyPress();
-                }
-                catch ( error )
-                {
-                    expect( onKeyPress ).not.toBeCalled();
-                }
-            } );
-        } );
     } );
 
 
@@ -519,34 +435,6 @@ describe( 'TagInputDriver', () =>
             {
                 const onKeyUp = jest.fn();
                 wrapper.setProps( { onKeyUp, isDisabled: true } );
-
-                try
-                {
-                    driver.keyUp();
-                }
-                catch ( error )
-                {
-                    expect( onKeyUp ).not.toBeCalled();
-                }
-            } );
-        } );
-
-
-        describe( 'isReadOnly', () =>
-        {
-            test( 'throws the expected error when isReadOnly', () =>
-            {
-                const expectedError =
-                    'TagInput cannot simulate keyUp since it is read only';
-                wrapper.setProps( { isReadOnly: true } );
-
-                expect( () => driver.keyUp() ).toThrow( expectedError );
-            } );
-
-            test( 'should not trigger onKeyUp when isReadOnly', () =>
-            {
-                const onKeyUp = jest.fn();
-                wrapper.setProps( { onKeyUp, isReadOnly: true } );
 
                 try
                 {
@@ -605,34 +493,6 @@ describe( 'TagInputDriver', () =>
                 }
             } );
         } );
-
-
-        describe( 'isReadOnly', () =>
-        {
-            test( 'throws the expected error when isReadOnly', () =>
-            {
-                const expectedError =
-                    'TagInput cannot simulate keyDown since it is read only';
-                wrapper.setProps( { isReadOnly: true } );
-
-                expect( () => driver.keyDown() ).toThrow( expectedError );
-            } );
-
-            test( 'should not trigger onKeyDown when isReadOnly', () =>
-            {
-                const onKeyDown = jest.fn();
-                wrapper.setProps( { onKeyDown, isReadOnly: true } );
-
-                try
-                {
-                    driver.keyDown();
-                }
-                catch ( error )
-                {
-                    expect( onKeyDown ).not.toBeCalled();
-                }
-            } );
-        } );
     } );
 
 
@@ -652,34 +512,6 @@ describe( 'TagInputDriver', () =>
             driver.mouseOut();
             expect( onMouseOut ).toBeCalledTimes( 1 );
         } );
-
-
-        describe( 'isDisabled', () =>
-        {
-            test( 'throws the expected error when isDisabled', () =>
-            {
-                const expectedError =
-                    'TagInput cannot simulate mouseOut since it is disabled';
-                wrapper.setProps( { isDisabled: true } );
-
-                expect( () => driver.mouseOut() ).toThrow( expectedError );
-            } );
-
-            test( 'should not trigger onMouseOut when isDisabled', () =>
-            {
-                const onMouseOut = jest.fn();
-                wrapper.setProps( { onMouseOut, isDisabled: true } );
-
-                try
-                {
-                    driver.mouseOut();
-                }
-                catch ( error )
-                {
-                    expect( onMouseOut ).not.toBeCalled();
-                }
-            } );
-        } );
     } );
 
 
@@ -698,34 +530,6 @@ describe( 'TagInputDriver', () =>
 
             driver.mouseOver();
             expect( onMouseOver ).toBeCalledTimes( 1 );
-        } );
-
-
-        describe( 'isDisabled', () =>
-        {
-            test( 'throws the expected error when isDisabled', () =>
-            {
-                const expectedError =
-                    'TagInput cannot simulate mouseOver since it is disabled';
-                wrapper.setProps( { isDisabled: true } );
-
-                expect( () => driver.mouseOver() ).toThrow( expectedError );
-            } );
-
-            test( 'should not trigger onMouseOver when isDisabled', () =>
-            {
-                const onMouseOver = jest.fn();
-                wrapper.setProps( { onMouseOver, isDisabled: true } );
-
-                try
-                {
-                    driver.mouseOver();
-                }
-                catch ( error )
-                {
-                    expect( onMouseOver ).not.toBeCalled();
-                }
-            } );
         } );
     } );
 } );

--- a/src/TextArea/driver.js
+++ b/src/TextArea/driver.js
@@ -28,11 +28,6 @@ export default class TextAreaDriver
             throw new Error( ERR.TEXTAREA_ERR( 'blur', 'disabled' ) );
         }
 
-        if ( this.wrapper.props().isReadOnly )
-        {
-            throw new Error( ERR.TEXTAREA_ERR( 'blur', 'read only' ) );
-        }
-
         this.wrapper.find( InputField ).driver().blur();
         return this;
     }
@@ -42,11 +37,6 @@ export default class TextAreaDriver
         if ( this.wrapper.props().isDisabled )
         {
             throw new Error( ERR.TEXTAREA_ERR( 'click', 'disabled' ) );
-        }
-
-        if ( this.wrapper.props().isReadOnly )
-        {
-            throw new Error( ERR.TEXTAREA_ERR( 'click', 'read only' ) );
         }
 
         this.wrapper.find( InputField ).driver().click();
@@ -76,11 +66,6 @@ export default class TextAreaDriver
             throw new Error( ERR.TEXTAREA_ERR( 'focus', 'disabled' ) );
         }
 
-        if ( this.wrapper.props().isReadOnly )
-        {
-            throw new Error( ERR.TEXTAREA_ERR( 'focus', 'read only' ) );
-        }
-
         this.wrapper.find( InputField ).driver().focus();
         return this;
     }
@@ -93,6 +78,28 @@ export default class TextAreaDriver
         }
 
         this.wrapper.find( InputField ).driver().keyPress( keyCode );
+        return this;
+    }
+
+    keyUp( keyCode )
+    {
+        if ( this.wrapper.props().isDisabled )
+        {
+            throw new Error( ERR.TEXTAREA_ERR( 'keyUp', 'disabled' ) );
+        }
+
+        this.wrapper.find( InputField ).driver().keyUp( keyCode );
+        return this;
+    }
+
+    keyDown( keyCode )
+    {
+        if ( this.wrapper.props().isDisabled )
+        {
+            throw new Error( ERR.TEXTAREA_ERR( 'keyDown', 'disabled' ) );
+        }
+
+        this.wrapper.find( InputField ).driver().keyDown( keyCode );
         return this;
     }
 

--- a/src/TextArea/tests.jsx
+++ b/src/TextArea/tests.jsx
@@ -102,34 +102,6 @@ describe( 'TextAreaDriver', () =>
                 }
             } );
         } );
-
-
-        describe( 'isReadOnly', () =>
-        {
-            test( 'throws the expected error when isReadOnly', () =>
-            {
-                const expectedError =
-                    'TextArea cannot simulate blur since it is read only';
-                wrapper.setProps( { isReadOnly: true } );
-
-                expect( () => driver.blur() ).toThrow( expectedError );
-            } );
-
-            test( 'should not trigger onBlur when isReadOnly', () =>
-            {
-                const onBlur = jest.fn();
-                wrapper.setProps( { onBlur, isReadOnly: true } );
-
-                try
-                {
-                    driver.blur();
-                }
-                catch ( error )
-                {
-                    expect( onBlur ).not.toBeCalled();
-                }
-            } );
-        } );
     } );
 
 
@@ -160,34 +132,6 @@ describe( 'TextAreaDriver', () =>
             {
                 const onFocus = jest.fn();
                 wrapper.setProps( { onFocus, isDisabled: true } );
-
-                try
-                {
-                    driver.focus();
-                }
-                catch ( error )
-                {
-                    expect( onFocus ).not.toBeCalled();
-                }
-            } );
-        } );
-
-
-        describe( 'isReadOnly', () =>
-        {
-            test( 'throws the expected error when isReadOnly', () =>
-            {
-                const expectedError =
-                    'TextArea cannot simulate focus since it is read only';
-                wrapper.setProps( { isReadOnly: true } );
-
-                expect( () => driver.focus() ).toThrow( expectedError );
-            } );
-
-            test( 'should not trigger onFocus when isReadOnly', () =>
-            {
-                const onFocus = jest.fn();
-                wrapper.setProps( { onFocus, isReadOnly: true } );
 
                 try
                 {
@@ -240,31 +184,126 @@ describe( 'TextAreaDriver', () =>
                 }
             } );
         } );
+    } );
 
 
-        describe( 'isReadOnly', () =>
+    describe( 'keyPress()', () =>
+    {
+        test( 'should trigger onKeyPress callback prop once', () =>
         {
-            test( 'throws the expected error when isReadOnly', () =>
+            const onKeyPress = jest.fn();
+            wrapper.setProps( {  onKeyPress } );
+
+            driver.keyPress();
+            expect( onKeyPress ).toBeCalledTimes( 1 );
+        } );
+
+
+        describe( 'isDisabled', () =>
+        {
+            test( 'throws the expected error when isDisabled', () =>
             {
                 const expectedError =
-                    'TextArea cannot simulate click since it is read only';
-                wrapper.setProps( { isReadOnly: true } );
+                    'TextArea cannot simulate keyPress since it is disabled';
+                wrapper.setProps( { isDisabled: true } );
 
-                expect( () => driver.click() ).toThrow( expectedError );
+                expect( () => driver.keyPress() ).toThrow( expectedError );
             } );
 
-            test( 'should not trigger onClick when isReadOnly', () =>
+            test( 'should not trigger onClick when isDisabled', () =>
             {
-                const onClick = jest.fn();
-                wrapper.setProps( { onClick, isReadOnly: true } );
+                const onKeyPress = jest.fn();
+                wrapper.setProps( { onKeyPress, isDisabled: true } );
 
                 try
                 {
-                    driver.click();
+                    driver.keyPress();
                 }
                 catch ( error )
                 {
-                    expect( onClick ).not.toBeCalled();
+                    expect( onKeyPress ).not.toBeCalled();
+                }
+            } );
+        } );
+    } );
+
+
+    describe( 'keyUp()', () =>
+    {
+        test( 'should trigger onKeyUp callback prop once', () =>
+        {
+            const onKeyUp = jest.fn();
+            wrapper.setProps( {  onKeyUp } );
+
+            driver.keyUp();
+            expect( onKeyUp ).toBeCalledTimes( 1 );
+        } );
+
+
+        describe( 'isDisabled', () =>
+        {
+            test( 'throws the expected error when isDisabled', () =>
+            {
+                const expectedError =
+                    'TextArea cannot simulate keyUp since it is disabled';
+                wrapper.setProps( { isDisabled: true } );
+
+                expect( () => driver.keyUp() ).toThrow( expectedError );
+            } );
+
+            test( 'should not trigger onClick when isDisabled', () =>
+            {
+                const onKeyUp = jest.fn();
+                wrapper.setProps( { onKeyUp, isDisabled: true } );
+
+                try
+                {
+                    driver.keyUp();
+                }
+                catch ( error )
+                {
+                    expect( onKeyUp ).not.toBeCalled();
+                }
+            } );
+        } );
+    } );
+
+
+    describe( 'keyDown()', () =>
+    {
+        test( 'should trigger onKeyDown callback prop once', () =>
+        {
+            const onKeyDown = jest.fn();
+            wrapper.setProps( {  onKeyDown } );
+
+            driver.keyDown();
+            expect( onKeyDown ).toBeCalledTimes( 1 );
+        } );
+
+
+        describe( 'isDisabled', () =>
+        {
+            test( 'throws the expected error when isDisabled', () =>
+            {
+                const expectedError =
+                    'TextArea cannot simulate keyDown since it is disabled';
+                wrapper.setProps( { isDisabled: true } );
+
+                expect( () => driver.keyDown() ).toThrow( expectedError );
+            } );
+
+            test( 'should not trigger onClick when isDisabled', () =>
+            {
+                const onKeyDown = jest.fn();
+                wrapper.setProps( { onKeyDown, isDisabled: true } );
+
+                try
+                {
+                    driver.keyDown();
+                }
+                catch ( error )
+                {
+                    expect( onKeyDown ).not.toBeCalled();
                 }
             } );
         } );

--- a/src/TextInput/driver.js
+++ b/src/TextInput/driver.js
@@ -19,11 +19,6 @@ export default class TextInputDriver
             throw new Error( ERR.TEXTINPUT_ERR( 'blur', 'disabled' ) );
         }
 
-        if ( this.wrapper.props().isReadOnly )
-        {
-            throw new Error( ERR.TEXTINPUT_ERR( 'blur', 'read only' ) );
-        }
-
         this.wrapper.find( InputField ).driver().blur();
         return this;
     }
@@ -33,11 +28,6 @@ export default class TextInputDriver
         if ( this.wrapper.props().isDisabled )
         {
             throw new Error( ERR.TEXTINPUT_ERR( 'click', 'disabled' ) );
-        }
-
-        if ( this.wrapper.props().isReadOnly )
-        {
-            throw new Error( ERR.TEXTINPUT_ERR( 'click', 'read only' ) );
         }
 
         this.wrapper.find( InputField ).driver().click();
@@ -67,11 +57,6 @@ export default class TextInputDriver
             throw new Error( ERR.TEXTINPUT_ERR( 'focus', 'disabled' ) );
         }
 
-        if ( this.wrapper.props().isReadOnly )
-        {
-            throw new Error( ERR.TEXTINPUT_ERR( 'focus', 'read only' ) );
-        }
-
         this.wrapper.find( InputField ).driver().focus();
         return this;
     }
@@ -84,6 +69,28 @@ export default class TextInputDriver
         }
 
         this.wrapper.find( InputField ).driver().keyPress( keyCode );
+        return this;
+    }
+
+    keyUp( keyCode )
+    {
+        if ( this.wrapper.props().isDisabled )
+        {
+            throw new Error( ERR.TEXTINPUT_ERR( 'keyUp', 'disabled' ) );
+        }
+
+        this.wrapper.find( InputField ).driver().keyUp( keyCode );
+        return this;
+    }
+
+    keyDown( keyCode )
+    {
+        if ( this.wrapper.props().isDisabled )
+        {
+            throw new Error( ERR.TEXTINPUT_ERR( 'keyDown', 'disabled' ) );
+        }
+
+        this.wrapper.find( InputField ).driver().keyDown( keyCode );
         return this;
     }
 

--- a/src/TextInput/tests.jsx
+++ b/src/TextInput/tests.jsx
@@ -107,7 +107,7 @@ describe( 'TextInputDriver', () =>
             wrapper.setProps( { onFocus } );
 
             driver.focus();
-            expect( onFocus ).toBeCalled();
+            expect( onFocus ).toBeCalledTimes( 1 );
         } );
 
 
@@ -148,7 +148,7 @@ describe( 'TextInputDriver', () =>
             wrapper.setProps( { onKeyPress } );
 
             driver.keyPress();
-            expect( onKeyPress ).toBeCalled();
+            expect( onKeyPress ).toBeCalledTimes( 1 );
         } );
 
 
@@ -230,7 +230,7 @@ describe( 'TextInputDriver', () =>
             wrapper.setProps( { onKeyDown } );
 
             driver.keyDown();
-            expect( onKeyDown ).toBeCalled();
+            expect( onKeyDown ).toBeCalledTimes( 1 );
         } );
 
 

--- a/src/TextInput/tests.jsx
+++ b/src/TextInput/tests.jsx
@@ -60,24 +60,23 @@ describe( 'TextInputDriver', () =>
 
     describe( 'blur()', () =>
     {
-        test( 'should fire the onBlur callback prop', () =>
+        test( 'should trigger onBlur callback prop once', () =>
         {
             const onBlur = jest.fn();
             wrapper.setProps( { hasError: false, onBlur } );
 
             driver.blur();
-            expect( onBlur ).toBeCalled();
+            expect( onBlur ).toBeCalledTimes( 1 );
         } );
 
 
         describe( 'isDisabled', () =>
         {
-            test( 'throws the expected error when isDisabled', () =>
+            test( 'should throw the expected error when isDisabled', () =>
             {
-                wrapper.setProps( { isDisabled: true } );
-
                 const expectedError =
                     'TextInput cannot simulate blur since it is disabled';
+                wrapper.setProps( { isDisabled: true } );
 
                 expect( () => driver.blur() ).toThrow( expectedError );
             } );
@@ -97,41 +96,12 @@ describe( 'TextInputDriver', () =>
                 }
             } );
         } );
-
-
-        describe( 'isReadOnly', () =>
-        {
-            test( 'throws the expected error when isReadOnly', () =>
-            {
-                wrapper.setProps( { isReadOnly: true } );
-
-                const expectedError =
-                    'TextInput cannot simulate blur since it is read only';
-
-                expect( () => driver.blur() ).toThrow( expectedError );
-            } );
-
-            test( 'should not trigger onBlur when isReadOnly', () =>
-            {
-                const onBlur = jest.fn();
-                wrapper.setProps( { onBlur, isReadOnly: true } );
-
-                try
-                {
-                    driver.blur();
-                }
-                catch ( error )
-                {
-                    expect( onBlur ).not.toBeCalled();
-                }
-            } );
-        } );
     } );
 
 
     describe( 'focus()', () =>
     {
-        test( 'should fire the onFocus callback prop', () =>
+        test( 'should trigger onFocus callback prop once', () =>
         {
             const onFocus = jest.fn();
             wrapper.setProps( { onFocus } );
@@ -143,12 +113,11 @@ describe( 'TextInputDriver', () =>
 
         describe( 'isDisabled', () =>
         {
-            test( 'throws the expected error when isDisabled', () =>
+            test( 'should throw the expected error when isDisabled', () =>
             {
-                wrapper.setProps( { isDisabled: true } );
-
                 const expectedError =
                     'TextInput cannot simulate focus since it is disabled';
+                wrapper.setProps( { isDisabled: true } );
 
                 expect( () => driver.focus() ).toThrow( expectedError );
             } );
@@ -168,41 +137,12 @@ describe( 'TextInputDriver', () =>
                 }
             } );
         } );
-
-
-        describe( 'isReadOnly', () =>
-        {
-            test( 'throws the expected error when isReadOnly', () =>
-            {
-                wrapper.setProps( { isReadOnly: true } );
-
-                const expectedError =
-                    'TextInput cannot simulate focus since it is read only';
-
-                expect( () => driver.focus() ).toThrow( expectedError );
-            } );
-
-            test( 'should not trigger onFocus when isReadOnly', () =>
-            {
-                const onFocus = jest.fn();
-                wrapper.setProps( { onFocus, isReadOnly: true } );
-
-                try
-                {
-                    driver.focus();
-                }
-                catch ( error )
-                {
-                    expect( onFocus ).not.toBeCalled();
-                }
-            } );
-        } );
     } );
 
 
     describe( 'keyPress()', () =>
     {
-        test( 'keyPress Text input should fire an event', () =>
+        test( 'should trigger onKeyPress callback prop once', () =>
         {
             const onKeyPress = jest.fn();
             wrapper.setProps( { onKeyPress } );
@@ -214,12 +154,11 @@ describe( 'TextInputDriver', () =>
 
         describe( 'isDisabled', () =>
         {
-            test( 'throws the expected error when isDisabled', () =>
+            test( 'should throw the expected error when isDisabled', () =>
             {
-                wrapper.setProps( { isDisabled: true } );
-
                 const expectedError =
                     'TextInput cannot simulate keyPress since it is disabled';
+                wrapper.setProps( { isDisabled: true } );
 
                 expect( () => driver.keyPress() ).toThrow( expectedError );
             } );
@@ -242,6 +181,88 @@ describe( 'TextInputDriver', () =>
     } );
 
 
+    describe( 'keyUp()', () =>
+    {
+        test( 'should trigger onKeyUp callback prop once', () =>
+        {
+            const onKeyUp = jest.fn();
+            wrapper.setProps( { onKeyUp } );
+
+            driver.keyUp();
+            expect( onKeyUp ).toBeCalledTimes( 1 );
+        } );
+
+
+        describe( 'isDisabled', () =>
+        {
+            test( 'should throw the expected error when isDisabled', () =>
+            {
+                const expectedError =
+                    'TextInput cannot simulate keyUp since it is disabled';
+                wrapper.setProps( { isDisabled: true } );
+
+                expect( () => driver.keyUp() ).toThrow( expectedError );
+            } );
+
+            test( 'should not trigger onKeyPress when isDisabled', () =>
+            {
+                const onKeyUp = jest.fn();
+                wrapper.setProps( { onKeyUp, isDisabled: true } );
+
+                try
+                {
+                    driver.keyUp();
+                }
+                catch ( error )
+                {
+                    expect( onKeyUp ).not.toBeCalled();
+                }
+            } );
+        } );
+    } );
+
+
+    describe( 'keyDown()', () =>
+    {
+        test( 'should trigger onKeyDown callback prop once', () =>
+        {
+            const onKeyDown = jest.fn();
+            wrapper.setProps( { onKeyDown } );
+
+            driver.keyDown();
+            expect( onKeyDown ).toBeCalled();
+        } );
+
+
+        describe( 'isDisabled', () =>
+        {
+            test( 'throws the expected error when isDisabled', () =>
+            {
+                const expectedError =
+                    'TextInput cannot simulate keyDown since it is disabled';
+                wrapper.setProps( { isDisabled: true } );
+
+                expect( () => driver.keyDown() ).toThrow( expectedError );
+            } );
+
+            test( 'should not trigger onKeyPress when isDisabled', () =>
+            {
+                const onKeyDown = jest.fn();
+                wrapper.setProps( { onKeyDown, isDisabled: true } );
+
+                try
+                {
+                    driver.keyDown();
+                }
+                catch ( error )
+                {
+                    expect( onKeyDown ).not.toBeCalled();
+                }
+            } );
+        } );
+    } );
+
+
     describe( 'change( val )', () =>
     {
         test( 'should trigger onChange callback prop once', () =>
@@ -258,10 +279,9 @@ describe( 'TextInputDriver', () =>
         {
             test( 'throws the expected error when isDisabled', () =>
             {
-                wrapper.setProps( { isDisabled: true } );
-
                 const expectedError =
                     'TextInput cannot simulate change since it is disabled';
+                wrapper.setProps( { isDisabled: true } );
 
                 expect( () => driver.change() ).toThrow( expectedError );
             } );
@@ -287,10 +307,9 @@ describe( 'TextInputDriver', () =>
         {
             test( 'throws the expected error when isReadOnly', () =>
             {
-                wrapper.setProps( { isReadOnly: true } );
-
                 const expectedError =
                     'TextInput cannot simulate change since it is read only';
+                wrapper.setProps( { isReadOnly: true } );
 
                 expect( () => driver.change() ).toThrow( expectedError );
             } );
@@ -321,7 +340,6 @@ describe( 'TextInputDriver', () =>
             wrapper.setProps( { onClick } );
 
             driver.click();
-
             expect( onClick ).toBeCalledTimes( 1 );
         } );
 
@@ -330,10 +348,9 @@ describe( 'TextInputDriver', () =>
         {
             test( 'throws the expected error when isDisabled', () =>
             {
-                wrapper.setProps( { isDisabled: true } );
-
                 const expectedError =
                     'TextInput cannot simulate click since it is disabled';
+                wrapper.setProps( { isDisabled: true } );
 
                 expect( () => driver.click() ).toThrow( expectedError );
             } );
@@ -342,35 +359,6 @@ describe( 'TextInputDriver', () =>
             {
                 const onClick = jest.fn();
                 wrapper.setProps( { onClick, isDisabled: true } );
-
-                try
-                {
-                    driver.click();
-                }
-                catch ( error )
-                {
-                    expect( onClick ).not.toBeCalled();
-                }
-            } );
-        } );
-
-
-        describe( 'isReadOnly', () =>
-        {
-            test( 'throws the expected error when isReadOnly', () =>
-            {
-                wrapper.setProps( { isReadOnly: true } );
-
-                const expectedError =
-                    'TextInput cannot simulate click since it is read only';
-
-                expect( () => driver.click() ).toThrow( expectedError );
-            } );
-
-            test( 'should not trigger onClick when isReadOnly', () =>
-            {
-                const onClick = jest.fn();
-                wrapper.setProps( { onClick, isReadOnly: true } );
 
                 try
                 {

--- a/src/ToggleButton/driver.js
+++ b/src/ToggleButton/driver.js
@@ -12,75 +12,6 @@ export default class ToggleButtonDriver
             .find( `.${this.wrapper.props().cssMap.default}` ).first();
     }
 
-    click()
-    {
-        const props = this.wrapper.props();
-        const label = this.wrapper.find( `.${props.cssMap.title}` ).text();
-
-        if ( props.isDisabled )
-        {
-            throw new Error( ERR
-                .TOGGLEBUTTON_ERR( label, 'click', 'disabled' ) );
-        }
-
-        if ( props.isReadOnly )
-        {
-            throw new Error( ERR
-                .TOGGLEBUTTON_ERR( label, 'click', 'read only' ) );
-        }
-
-        if ( props.isLoading )
-        {
-            throw new Error( ERR
-                .TOGGLEBUTTON_ERR( label, 'click', 'loading' ) );
-        }
-
-        this.button.simulate( 'click' );
-        return this;
-    }
-
-    mouseOver()
-    {
-        const props = this.wrapper.props();
-        const label = this.wrapper.find( `.${props.cssMap.title}` ).text();
-
-        if ( props.isDisabled )
-        {
-            throw new Error( ERR
-                .TOGGLEBUTTON_ERR( label, 'mouseOver', 'disabled' ) );
-        }
-
-        if ( props.isLoading )
-        {
-            throw new Error( ERR
-                .TOGGLEBUTTON_ERR( label, 'mouseOver', 'loading' ) );
-        }
-
-        this.button.simulate( 'mouseenter' );
-        return this;
-    }
-
-    mouseOut()
-    {
-        const props = this.wrapper.props();
-        const label = this.wrapper.find( `.${props.cssMap.title}` ).text();
-
-        if ( props.isDisabled )
-        {
-            throw new Error( ERR
-                .TOGGLEBUTTON_ERR( label, 'mouseOut', 'disabled' ) );
-        }
-
-        if ( props.isLoading )
-        {
-            throw new Error( ERR
-                .TOGGLEBUTTON_ERR( label, 'mouseOut', 'loading' ) );
-        }
-
-        this.button.simulate( 'mouseleave' );
-        return this;
-    }
-
     focus()
     {
         const props = this.wrapper.props();
@@ -90,18 +21,6 @@ export default class ToggleButtonDriver
         {
             throw new Error( ERR
                 .TOGGLEBUTTON_ERR( label, 'focus', 'disabled' ) );
-        }
-
-        if ( props.isReadOnly )
-        {
-            throw new Error( ERR
-                .TOGGLEBUTTON_ERR( label, 'focus', 'read only' ) );
-        }
-
-        if ( props.isLoading )
-        {
-            throw new Error( ERR
-                .TOGGLEBUTTON_ERR( label, 'focus', 'loading' ) );
         }
 
         this.button.simulate( 'focus' );
@@ -119,19 +38,52 @@ export default class ToggleButtonDriver
                 .TOGGLEBUTTON_ERR( label, 'blur', 'disabled' ) );
         }
 
-        if ( props.isReadOnly )
-        {
-            throw new Error( ERR
-                .TOGGLEBUTTON_ERR( label, 'blur', 'read only' ) );
-        }
-
-        if ( props.isLoading )
-        {
-            throw new Error( ERR
-                .TOGGLEBUTTON_ERR( label, 'blur', 'loading' ) );
-        }
-
         this.button.simulate( 'blur' );
+        return this;
+    }
+
+    click()
+    {
+        const props = this.wrapper.props();
+        const label = this.wrapper.find( `.${props.cssMap.title}` ).text();
+
+        if ( props.isDisabled )
+        {
+            throw new Error( ERR
+                .TOGGLEBUTTON_ERR( label, 'click', 'disabled' ) );
+        }
+
+        this.button.simulate( 'click' );
+        return this;
+    }
+
+    mouseOver()
+    {
+        const props = this.wrapper.props();
+        const label = this.wrapper.find( `.${props.cssMap.title}` ).text();
+
+        if ( props.isDisabled )
+        {
+            throw new Error( ERR
+                .TOGGLEBUTTON_ERR( label, 'mouseOver', 'disabled' ) );
+        }
+
+        this.button.simulate( 'mouseenter' );
+        return this;
+    }
+
+    mouseOut()
+    {
+        const props = this.wrapper.props();
+        const label = this.wrapper.find( `.${props.cssMap.title}` ).text();
+
+        if ( props.isDisabled )
+        {
+            throw new Error( ERR
+                .TOGGLEBUTTON_ERR( label, 'mouseOut', 'disabled' ) );
+        }
+
+        this.button.simulate( 'mouseleave' );
         return this;
     }
 }

--- a/src/ToggleButton/driver.js
+++ b/src/ToggleButton/driver.js
@@ -15,7 +15,7 @@ export default class ToggleButtonDriver
     click()
     {
         const props = this.wrapper.props();
-        const { label } = props;
+        const label = this.wrapper.find( `.${props.cssMap.title}` ).text();
 
         if ( props.isDisabled )
         {
@@ -42,7 +42,7 @@ export default class ToggleButtonDriver
     mouseOver()
     {
         const props = this.wrapper.props();
-        const { label } = props;
+        const label = this.wrapper.find( `.${props.cssMap.title}` ).text();
 
         if ( props.isDisabled )
         {
@@ -63,7 +63,7 @@ export default class ToggleButtonDriver
     mouseOut()
     {
         const props = this.wrapper.props();
-        const { label } = props;
+        const label = this.wrapper.find( `.${props.cssMap.title}` ).text();
 
         if ( props.isDisabled )
         {
@@ -84,7 +84,7 @@ export default class ToggleButtonDriver
     focus()
     {
         const props = this.wrapper.props();
-        const { label } = props;
+        const label = this.wrapper.find( `.${props.cssMap.title}` ).text();
 
         if ( props.isDisabled )
         {
@@ -111,7 +111,7 @@ export default class ToggleButtonDriver
     blur()
     {
         const props = this.wrapper.props();
-        const { label } = props;
+        const label = this.wrapper.find( `.${props.cssMap.title}` ).text();
 
         if ( props.isDisabled )
         {

--- a/src/ToggleButton/tests.jsx
+++ b/src/ToggleButton/tests.jsx
@@ -196,6 +196,88 @@ describe( 'ToggleButtonDriver', () =>
         } );
     } );
 
+
+    describe( 'blur()', () =>
+    {
+        test( 'should trigger onBlur callback prop once', () =>
+        {
+            const onBlur = jest.fn();
+            wrapper.setProps( { onBlur } );
+
+            driver.blur();
+            expect( onBlur ).toBeCalledTimes( 1 );
+        } );
+
+
+        describe( 'isDisabled', () =>
+        {
+            test( 'throws the expected error when isDisabled', () =>
+            {
+                const expectedError = 'ToggleButton \'Tekeli-li\' cannot \
+simulate blur since it is disabled';
+                wrapper.setProps( { isDisabled: true, label: 'Tekeli-li' } );
+
+                expect( () => driver.blur() ).toThrow( expectedError );
+            } );
+
+            test( 'should not trigger onBlur when isDisabled', () =>
+            {
+                const onBlur = jest.fn();
+                wrapper.setProps( { onBlur, isDisabled: true } );
+
+                try
+                {
+                    driver.blur();
+                }
+                catch ( error )
+                {
+                    expect( onBlur ).not.toBeCalled();
+                }
+            } );
+        } );
+    } );
+
+
+    describe( 'focus()', () =>
+    {
+        test( 'should trigger onFocus callback prop once', () =>
+        {
+            const onFocus = jest.fn();
+            wrapper.setProps( { onFocus } );
+
+            driver.focus();
+            expect( onFocus ).toBeCalledTimes( 1 );
+        } );
+
+
+        describe( 'isDisabled', () =>
+        {
+            test( 'throws the expected error when isDisabled', () =>
+            {
+                const expectedError = 'ToggleButton \'Tekeli-li\' cannot \
+simulate focus since it is disabled';
+                wrapper.setProps( { isDisabled: true, label: 'Tekeli-li' } );
+
+                expect( () => driver.focus() ).toThrow( expectedError );
+            } );
+
+            test( 'should not trigger onFocus when isDisabled', () =>
+            {
+                const onFocus = jest.fn();
+                wrapper.setProps( { onFocus, isDisabled: true } );
+
+                try
+                {
+                    driver.focus();
+                }
+                catch ( error )
+                {
+                    expect( onFocus ).not.toBeCalled();
+                }
+            } );
+        } );
+    } );
+
     describe( 'click', () =>
     {
         test( 'should trigger onClick callback prop once', () =>
@@ -223,34 +305,6 @@ simulate click since it is disabled';
             {
                 const onClick = jest.fn();
                 wrapper.setProps( { onClick, isDisabled: true } );
-
-                try
-                {
-                    driver.click();
-                }
-                catch ( error )
-                {
-                    expect( onClick ).not.toBeCalled();
-                }
-            } );
-        } );
-
-
-        describe( 'isReadOnly', () =>
-        {
-            test( 'throws the expected error when isReadOnly', () =>
-            {
-                const expectedError = 'ToggleButton \'Tekeli-li\' cannot \
-simulate click since it is read only';
-                wrapper.setProps( { isReadOnly: true, label: 'Tekeli-li' } );
-
-                expect( () => driver.click() ).toThrow( expectedError );
-            } );
-
-            test( 'should not trigger onClick when isReadOnly', () =>
-            {
-                const onClick = jest.fn();
-                wrapper.setProps( { onClick, isReadOnly: true } );
 
                 try
                 {
@@ -342,148 +396,6 @@ simulate mouseOut since it is disabled';
                 catch ( error )
                 {
                     expect( onMouseOut ).not.toBeCalled();
-                }
-            } );
-        } );
-    } );
-
-
-    describe( 'blur()', () =>
-    {
-        test( 'should trigger onBlur callback prop once', () =>
-        {
-            const onBlur = jest.fn();
-            wrapper.setProps( { onBlur } );
-
-            driver.blur();
-            expect( onBlur ).toBeCalledTimes( 1 );
-        } );
-
-
-        describe( 'isDisabled', () =>
-        {
-            test( 'throws the expected error when isDisabled', () =>
-            {
-                wrapper.setProps( { isDisabled: true, label: 'Tekeli-li' } );
-
-                const expectedError = 'ToggleButton \'Tekeli-li\' cannot \
-simulate blur since it is disabled';
-
-                expect( () => driver.blur() ).toThrow( expectedError );
-            } );
-
-            test( 'should not trigger onBlur when isDisabled', () =>
-            {
-                const onBlur = jest.fn();
-                wrapper.setProps( { onBlur, isDisabled: true } );
-
-                try
-                {
-                    driver.blur();
-                }
-                catch ( error )
-                {
-                    expect( onBlur ).not.toBeCalled();
-                }
-            } );
-        } );
-
-
-        describe( 'isReadOnly', () =>
-        {
-            test( 'throws the expected error when isReadOnly', () =>
-            {
-                wrapper.setProps( { isReadOnly: true, label: 'Tekeli-li' } );
-
-                const expectedError = 'ToggleButton \'Tekeli-li\' cannot \
-simulate blur since it is read only';
-
-                expect( () => driver.blur() ).toThrow( expectedError );
-            } );
-
-            test( 'should not trigger onBlur when isReadOnly', () =>
-            {
-                const onBlur = jest.fn();
-                wrapper.setProps( { onBlur, isReadOnly: true } );
-
-                try
-                {
-                    driver.blur();
-                }
-                catch ( error )
-                {
-                    expect( onBlur ).not.toBeCalled();
-                }
-            } );
-        } );
-    } );
-
-
-    describe( 'focus()', () =>
-    {
-        test( 'should trigger onFocus callback prop once', () =>
-        {
-            const onFocus = jest.fn();
-            wrapper.setProps( { onFocus } );
-
-            driver.focus();
-            expect( onFocus ).toBeCalledTimes( 1 );
-        } );
-
-
-        describe( 'isDisabled', () =>
-        {
-            test( 'throws the expected error when isDisabled', () =>
-            {
-                wrapper.setProps( { isDisabled: true, label: 'Tekeli-li' } );
-
-                const expectedError = 'ToggleButton \'Tekeli-li\' cannot \
-simulate focus since it is disabled';
-
-                expect( () => driver.focus() ).toThrow( expectedError );
-            } );
-
-            test( 'should not trigger onFocus when isDisabled', () =>
-            {
-                const onFocus = jest.fn();
-                wrapper.setProps( { onFocus, isDisabled: true } );
-
-                try
-                {
-                    driver.focus();
-                }
-                catch ( error )
-                {
-                    expect( onFocus ).not.toBeCalled();
-                }
-            } );
-        } );
-
-
-        describe( 'isReadOnly', () =>
-        {
-            test( 'throws the expected error when isReadOnly', () =>
-            {
-                wrapper.setProps( { isReadOnly: true, label: 'Tekeli-li' } );
-
-                const expectedError = 'ToggleButton \'Tekeli-li\' cannot \
-simulate focus since it is read only';
-
-                expect( () => driver.focus() ).toThrow( expectedError );
-            } );
-
-            test( 'should not trigger onFocus when isReadOnly', () =>
-            {
-                const onFocus = jest.fn();
-                wrapper.setProps( { onFocus, isReadOnly: true } );
-
-                try
-                {
-                    driver.focus();
-                }
-                catch ( error )
-                {
-                    expect( onFocus ).not.toBeCalled();
                 }
             } );
         } );

--- a/src/Uploader/driver.js
+++ b/src/Uploader/driver.js
@@ -50,6 +50,7 @@ export default class UploaderDriver
 
         node.name = val;
         this.wrapper.find( `.${this.cssMap.input}` ).simulate( 'change' );
+
         return this;
     }
 

--- a/src/ValuedTextInput/driver.js
+++ b/src/ValuedTextInput/driver.js
@@ -1,4 +1,5 @@
 import { InputField } from '../index';
+import InputContainer from '../proto/InputContainer';
 
 const ERR = {
     VALUEDTEXTINPUT_ERR : ( event, state ) =>
@@ -90,13 +91,13 @@ export default class ValuedTextInputDriver
 
     mouseOver()
     {
-        this.wrapper.find( 'InputContainer' ).simulate( 'mouseenter' );
+        this.wrapper.find( InputContainer ).simulate( 'mouseenter' );
         return this;
     }
 
     mouseOut()
     {
-        this.wrapper.find( 'InputContainer' ).simulate( 'mouseleave' );
+        this.wrapper.find( InputContainer ).simulate( 'mouseleave' );
         return this;
     }
 }

--- a/src/ValuedTextInput/driver.js
+++ b/src/ValuedTextInput/driver.js
@@ -19,11 +19,6 @@ export default class ValuedTextInputDriver
             throw new Error( ERR.VALUEDTEXTINPUT_ERR( 'blur', 'disabled' ) );
         }
 
-        if ( this.wrapper.props().isReadOnly )
-        {
-            throw new Error( ERR.VALUEDTEXTINPUT_ERR( 'blur', 'read only' ) );
-        }
-
         this.wrapper.find( InputField ).driver().blur();
         return this;
     }
@@ -33,11 +28,6 @@ export default class ValuedTextInputDriver
         if ( this.wrapper.props().isDisabled )
         {
             throw new Error( ERR.VALUEDTEXTINPUT_ERR( 'click', 'disabled' ) );
-        }
-
-        if ( this.wrapper.props().isReadOnly )
-        {
-            throw new Error( ERR.VALUEDTEXTINPUT_ERR( 'click', 'read only' ) );
         }
 
         this.wrapper.find( InputField ).driver().click();
@@ -67,11 +57,6 @@ export default class ValuedTextInputDriver
             throw new Error( ERR.VALUEDTEXTINPUT_ERR( 'focus', 'disabled' ) );
         }
 
-        if ( this.wrapper.props().isReadOnly )
-        {
-            throw new Error( ERR.VALUEDTEXTINPUT_ERR( 'focus', 'read only' ) );
-        }
-
         this.wrapper.find( InputField ).driver().focus();
         return this;
     }
@@ -85,6 +70,30 @@ export default class ValuedTextInputDriver
         }
 
         this.wrapper.find( InputField ).driver().keyPress( keyCode );
+        return this;
+    }
+
+    keyUp( keyCode )
+    {
+        if ( this.wrapper.props().isDisabled )
+        {
+            throw new Error( ERR
+                .VALUEDTEXTINPUT_ERR( 'keyUp', 'disabled' ) );
+        }
+
+        this.wrapper.find( InputField ).driver().keyUp( keyCode );
+        return this;
+    }
+
+    keyDown( keyCode )
+    {
+        if ( this.wrapper.props().isDisabled )
+        {
+            throw new Error( ERR
+                .VALUEDTEXTINPUT_ERR( 'keyDown', 'disabled' ) );
+        }
+
+        this.wrapper.find( InputField ).driver().keyDown( keyCode );
         return this;
     }
 

--- a/src/ValuedTextInput/tests.jsx
+++ b/src/ValuedTextInput/tests.jsx
@@ -103,34 +103,6 @@ describe( 'ValuedTextInputDriver', () =>
                 }
             } );
         } );
-
-
-        describe( 'isReadOnly', () =>
-        {
-            test( 'throws the expected error when isReadOnly', () =>
-            {
-                const expectedError = 'ValuedTextInput cannot simulate blur \
-since it is read only';
-                wrapper.setProps( { isReadOnly: true } );
-
-                expect( () => driver.blur() ).toThrow( expectedError );
-            } );
-
-            test( 'should not trigger onBlur when isReadOnly', () =>
-            {
-                const onBlur = jest.fn();
-                wrapper.setProps( { onBlur, isReadOnly: true } );
-
-                try
-                {
-                    driver.blur();
-                }
-                catch ( error )
-                {
-                    expect( onBlur ).not.toBeCalled();
-                }
-            } );
-        } );
     } );
 
 
@@ -161,34 +133,6 @@ since it is disabled';
             {
                 const onFocus = jest.fn();
                 wrapper.setProps( { onFocus, isDisabled: true } );
-
-                try
-                {
-                    driver.focus();
-                }
-                catch ( error )
-                {
-                    expect( onFocus ).not.toBeCalled();
-                }
-            } );
-        } );
-
-
-        describe( 'isReadOnly', () =>
-        {
-            test( 'throws the expected error when isReadOnly', () =>
-            {
-                const expectedError = 'ValuedTextInput cannot simulate focus \
-since it is read only';
-                wrapper.setProps( { isReadOnly: true } );
-
-                expect( () => driver.focus() ).toThrow( expectedError );
-            } );
-
-            test( 'should not trigger onFocus when isReadOnly', () =>
-            {
-                const onFocus = jest.fn();
-                wrapper.setProps( { onFocus, isReadOnly: true } );
 
                 try
                 {
@@ -238,6 +182,88 @@ keyPress since it is disabled';
                 catch ( error )
                 {
                     expect( onKeyPress ).not.toBeCalled();
+                }
+            } );
+        } );
+    } );
+
+
+    describe( 'keyUp()', () =>
+    {
+        test( 'should trigger onKeyUp callback prop once', () =>
+        {
+            const onKeyUp = jest.fn();
+            wrapper.setProps( { onKeyUp } );
+
+            driver.keyUp();
+            expect( onKeyUp ).toBeCalled();
+        } );
+
+
+        describe( 'isDisabled', () =>
+        {
+            test( 'throws the expected error when isDisabled', () =>
+            {
+                const expectedError = 'ValuedTextInput cannot simulate \
+keyUp since it is disabled';
+                wrapper.setProps( { isDisabled: true } );
+
+                expect( () => driver.keyUp() ).toThrow( expectedError );
+            } );
+
+            test( 'should not trigger onKeyUp when isDisabled', () =>
+            {
+                const onKeyUp = jest.fn();
+                wrapper.setProps( { onKeyUp, isDisabled: true } );
+
+                try
+                {
+                    driver.keyUp();
+                }
+                catch ( error )
+                {
+                    expect( onKeyUp ).not.toBeCalled();
+                }
+            } );
+        } );
+    } );
+
+
+    describe( 'keyDown()', () =>
+    {
+        test( 'should trigger onKeyDown callback prop once', () =>
+        {
+            const onKeyDown = jest.fn();
+            wrapper.setProps( { onKeyDown } );
+
+            driver.keyDown();
+            expect( onKeyDown ).toBeCalled();
+        } );
+
+
+        describe( 'isDisabled', () =>
+        {
+            test( 'throws the expected error when isDisabled', () =>
+            {
+                const expectedError = 'ValuedTextInput cannot simulate \
+keyDown since it is disabled';
+                wrapper.setProps( { isDisabled: true } );
+
+                expect( () => driver.keyDown() ).toThrow( expectedError );
+            } );
+
+            test( 'should not trigger onKeyDown when isDisabled', () =>
+            {
+                const onKeyDown = jest.fn();
+                wrapper.setProps( { onKeyDown, isDisabled: true } );
+
+                try
+                {
+                    driver.keyDown();
+                }
+                catch ( error )
+                {
+                    expect( onKeyDown ).not.toBeCalled();
                 }
             } );
         } );
@@ -340,34 +366,6 @@ since it is disabled';
             {
                 const onClick = jest.fn();
                 wrapper.setProps( { onClick, isDisabled: true } );
-
-                try
-                {
-                    driver.click();
-                }
-                catch ( error )
-                {
-                    expect( onClick ).not.toBeCalled();
-                }
-            } );
-        } );
-
-
-        describe( 'isReadOnly', () =>
-        {
-            test( 'throws the expected error when isReadOnly', () =>
-            {
-                const expectedError = 'ValuedTextInput cannot simulate click \
-since it is read only';
-                wrapper.setProps( { isReadOnly: true } );
-
-                expect( () => driver.click() ).toThrow( expectedError );
-            } );
-
-            test( 'should not trigger onClick when isReadOnly', () =>
-            {
-                const onClick = jest.fn();
-                wrapper.setProps( { onClick, isReadOnly: true } );
 
                 try
                 {


### PR DESCRIPTION
For #670:

- updated driver error messages where `label` was used to either include `children` when provided (which overrides 'label') or removed 'label' from message
- minor tweaks in drivers (components importing)