### PR TITLE
[Drivers] remove errors that don't apply

### DIFF
--- a/src/InputField/driver.js
+++ b/src/InputField/driver.js
@@ -14,14 +14,7 @@ export default class InputFieldDriver
     {
         if ( this.wrapper.props().isDisabled )
         {
-            throw new Error( ERR
-                .INPUTFIELD_ERROR( 'blur', 'disabled' ) );
-        }
-
-        if ( this.wrapper.props().isReadOnly )
-        {
-            throw new Error( ERR
-                .INPUTFIELD_ERROR( 'blur', 'read only' ) );
+            throw new Error( ERR.INPUTFIELD_ERROR( 'blur', 'disabled' ) );
         }
 
         this.wrapper.simulate( 'blur' );
@@ -32,14 +25,7 @@ export default class InputFieldDriver
     {
         if ( this.wrapper.props().isDisabled )
         {
-            throw new Error( ERR
-                .INPUTFIELD_ERROR( 'focus', 'disabled' ) );
-        }
-
-        if ( this.wrapper.props().isReadOnly )
-        {
-            throw new Error( ERR
-                .INPUTFIELD_ERROR( 'focus', 'read only' ) );
+            throw new Error( ERR.INPUTFIELD_ERROR( 'focus', 'disabled' ) );
         }
 
         this.wrapper.simulate( 'focus' );
@@ -52,14 +38,12 @@ export default class InputFieldDriver
 
         if ( this.wrapper.props().isDisabled )
         {
-            throw new Error( ERR
-                .INPUTFIELD_ERROR( 'change', 'disabled' ) );
+            throw new Error( ERR.INPUTFIELD_ERROR( 'change', 'disabled' ) );
         }
 
         if ( this.wrapper.props().isReadOnly )
         {
-            throw new Error( ERR
-                .INPUTFIELD_ERROR( 'change', 'read only' ) );
+            throw new Error( ERR.INPUTFIELD_ERROR( 'change', 'read only' ) );
         }
 
         node.value = val;
@@ -72,14 +56,7 @@ export default class InputFieldDriver
     {
         if ( this.wrapper.props().isDisabled )
         {
-            throw new Error( ERR
-                .INPUTFIELD_ERROR( 'click', 'disabled' ) );
-        }
-
-        if ( this.wrapper.props().isReadOnly )
-        {
-            throw new Error( ERR
-                .INPUTFIELD_ERROR( 'click', 'read only' ) );
+            throw new Error( ERR.INPUTFIELD_ERROR( 'click', 'disabled' ) );
         }
 
         this.wrapper.simulate( 'click' );
@@ -90,14 +67,7 @@ export default class InputFieldDriver
     {
         if ( this.wrapper.props().isDisabled )
         {
-            throw new Error( ERR
-                .INPUTFIELD_ERROR( 'keyPress', 'disabled' ) );
-        }
-
-        if ( this.wrapper.props().isReadOnly )
-        {
-            throw new Error( ERR
-                .INPUTFIELD_ERROR( 'keyPress', 'read only' ) );
+            throw new Error( ERR.INPUTFIELD_ERROR( 'keyPress', 'disabled' ) );
         }
 
         this.wrapper.simulate( 'keyPress', { keyCode } );
@@ -108,14 +78,7 @@ export default class InputFieldDriver
     {
         if ( this.wrapper.props().isDisabled )
         {
-            throw new Error( ERR
-                .INPUTFIELD_ERROR( 'keyDown', 'disabled' ) );
-        }
-
-        if ( this.wrapper.props().isReadOnly )
-        {
-            throw new Error( ERR
-                .INPUTFIELD_ERROR( 'keyDown', 'read only' ) );
+            throw new Error( ERR.INPUTFIELD_ERROR( 'keyDown', 'disabled' ) );
         }
 
         this.wrapper.simulate( 'keyDown', { keyCode } );
@@ -126,14 +89,7 @@ export default class InputFieldDriver
     {
         if ( this.wrapper.props().isDisabled )
         {
-            throw new Error( ERR
-                .INPUTFIELD_ERROR( 'keyUp', 'disabled' ) );
-        }
-
-        if ( this.wrapper.props().isReadOnly )
-        {
-            throw new Error( ERR
-                .INPUTFIELD_ERROR( 'keyUp', 'read only' ) );
+            throw new Error( ERR.INPUTFIELD_ERROR( 'keyUp', 'disabled' ) );
         }
 
         this.wrapper.simulate( 'keyUp', { keyCode } );
@@ -142,36 +98,12 @@ export default class InputFieldDriver
 
     mouseOver()
     {
-        if ( this.wrapper.props().isDisabled )
-        {
-            throw new Error( ERR
-                .INPUTFIELD_ERROR( 'mouseOver', 'disabled' ) );
-        }
-
-        if ( this.wrapper.props().isReadOnly )
-        {
-            throw new Error( ERR
-                .INPUTFIELD_ERROR( 'mouseOver', 'read only' ) );
-        }
-
         this.wrapper.simulate( 'mouseenter' );
         return this;
     }
 
     mouseOut()
     {
-        if ( this.wrapper.props().isDisabled )
-        {
-            throw new Error( ERR
-                .INPUTFIELD_ERROR( 'mouseOut', 'disabled' ) );
-        }
-
-        if ( this.wrapper.props().isReadOnly )
-        {
-            throw new Error( ERR
-                .INPUTFIELD_ERROR( 'mouseOut', 'read only' ) );
-        }
-
         this.wrapper.simulate( 'mouseleave' );
         return this;
     }

--- a/src/InputField/tests.jsx
+++ b/src/InputField/tests.jsx
@@ -370,34 +370,6 @@ describe( 'InputFieldDriver', () =>
                 }
             } );
         } );
-
-
-        describe( 'isReadOnly', () =>
-        {
-            test( 'throws the expected error when isReadOnly', () =>
-            {
-                const expectedError =
-                    'InputField cannot simulate blur since it is read only';
-                wrapper.setProps( { isReadOnly: true } );
-
-                expect( () => driver.blur() ).toThrow( expectedError );
-            } );
-
-            test( 'should not trigger onBlur when isReadOnly', () =>
-            {
-                const onBlur = jest.fn();
-                wrapper.setProps( { onBlur, isReadOnly: true } );
-
-                try
-                {
-                    driver.blur();
-                }
-                catch ( error )
-                {
-                    expect( onBlur ).not.toBeCalled();
-                }
-            } );
-        } );
     } );
 
 
@@ -428,34 +400,6 @@ describe( 'InputFieldDriver', () =>
             {
                 const onFocus = jest.fn();
                 wrapper.setProps( { onFocus, isDisabled: true } );
-
-                try
-                {
-                    driver.focus();
-                }
-                catch ( error )
-                {
-                    expect( onFocus ).not.toBeCalled();
-                }
-            } );
-        } );
-
-
-        describe( 'isReadOnly', () =>
-        {
-            test( 'throws the expected error when isReadOnly', () =>
-            {
-                const expectedError =
-                    'InputField cannot simulate focus since it is read only';
-                wrapper.setProps( { isReadOnly: true } );
-
-                expect( () => driver.focus() ).toThrow( expectedError );
-            } );
-
-            test( 'should not trigger onFocus when isReadOnly', () =>
-            {
-                const onFocus = jest.fn();
-                wrapper.setProps( { onFocus, isReadOnly: true } );
 
                 try
                 {
@@ -577,34 +521,6 @@ describe( 'InputFieldDriver', () =>
                 }
             } );
         } );
-
-
-        describe( 'isReadOnly', () =>
-        {
-            test( 'throws the expected error when isReadOnly', () =>
-            {
-                const expectedError =
-                    'InputField cannot simulate click since it is read only';
-                wrapper.setProps( { isReadOnly: true } );
-
-                expect( () => driver.click() ).toThrow( expectedError );
-            } );
-
-            test( 'should not trigger onClick when isReadOnly', () =>
-            {
-                const onClick = jest.fn();
-                wrapper.setProps( { onClick, isReadOnly: true } );
-
-                try
-                {
-                    driver.click();
-                }
-                catch ( error )
-                {
-                    expect( onClick ).not.toBeCalled();
-                }
-            } );
-        } );
     } );
 
 
@@ -635,34 +551,6 @@ describe( 'InputFieldDriver', () =>
             {
                 const onKeyPress = jest.fn();
                 wrapper.setProps( { onKeyPress, isDisabled: true } );
-
-                try
-                {
-                    driver.keyPress();
-                }
-                catch ( error )
-                {
-                    expect( onKeyPress ).not.toBeCalled();
-                }
-            } );
-        } );
-
-
-        describe( 'isReadOnly', () =>
-        {
-            test( 'throws the expected error when isReadOnly', () =>
-            {
-                const expectedError =
-                    'InputField cannot simulate keyPress since it is read only';
-                wrapper.setProps( { isReadOnly: true } );
-
-                expect( () => driver.keyPress() ).toThrow( expectedError );
-            } );
-
-            test( 'should not trigger onKeyPress when isReadOnly', () =>
-            {
-                const onKeyPress = jest.fn();
-                wrapper.setProps( { onKeyPress, isReadOnly: true } );
 
                 try
                 {
@@ -715,34 +603,6 @@ describe( 'InputFieldDriver', () =>
                 }
             } );
         } );
-
-
-        describe( 'isReadOnly', () =>
-        {
-            test( 'throws the expected error when isReadOnly', () =>
-            {
-                const expectedError =
-                    'InputField cannot simulate keyDown since it is read only';
-                wrapper.setProps( { isReadOnly: true } );
-
-                expect( () => driver.keyDown() ).toThrow( expectedError );
-            } );
-
-            test( 'should not trigger onKeyDown when isReadOnly', () =>
-            {
-                const onKeyDown = jest.fn();
-                wrapper.setProps( { onKeyDown, isReadOnly: true } );
-
-                try
-                {
-                    driver.keyDown();
-                }
-                catch ( error )
-                {
-                    expect( onKeyDown ).not.toBeCalled();
-                }
-            } );
-        } );
     } );
 
 
@@ -784,34 +644,6 @@ describe( 'InputFieldDriver', () =>
                 }
             } );
         } );
-
-
-        describe( 'isReadOnly', () =>
-        {
-            test( 'throws the expected error when isReadOnly', () =>
-            {
-                const expectedError =
-                    'InputField cannot simulate keyUp since it is read only';
-                wrapper.setProps( { isReadOnly: true } );
-
-                expect( () => driver.keyUp() ).toThrow( expectedError );
-            } );
-
-            test( 'should not trigger onKeyUp when isReadOnly', () =>
-            {
-                const onKeyUp = jest.fn();
-                wrapper.setProps( { onKeyUp, isReadOnly: true } );
-
-                try
-                {
-                    driver.keyUp();
-                }
-                catch ( error )
-                {
-                    expect( onKeyUp ).not.toBeCalled();
-                }
-            } );
-        } );
     } );
 
 
@@ -825,62 +657,6 @@ describe( 'InputFieldDriver', () =>
             driver.mouseOver();
             expect( onMouseOver ).toBeCalledTimes( 1 );
         } );
-
-
-        describe( 'isDisabled', () =>
-        {
-            test( 'throws the expected error when isDisabled', () =>
-            {
-                const expectedError =
-                    'InputField cannot simulate mouseOver since it is disabled';
-                wrapper.setProps( { isDisabled: true } );
-
-                expect( () => driver.mouseOver() ).toThrow( expectedError );
-            } );
-
-            test( 'should not trigger onMouseOver when isDisabled', () =>
-            {
-                const onMouseOver = jest.fn();
-                wrapper.setProps( { onMouseOver, isDisabled: true } );
-
-                try
-                {
-                    driver.mouseOver();
-                }
-                catch ( error )
-                {
-                    expect( onMouseOver ).not.toBeCalled();
-                }
-            } );
-        } );
-
-
-        describe( 'isReadOnly', () =>
-        {
-            test( 'throws the expected error when isReadOnly', () =>
-            {
-                const expectedError = 'InputField cannot simulate mouseOver \
-since it is read only';
-                wrapper.setProps( { isReadOnly: true } );
-
-                expect( () => driver.mouseOver() ).toThrow( expectedError );
-            } );
-
-            test( 'should not trigger onMouseOver when isReadOnly', () =>
-            {
-                const onMouseOver = jest.fn();
-                wrapper.setProps( { onMouseOver, isReadOnly: true } );
-
-                try
-                {
-                    driver.mouseOver();
-                }
-                catch ( error )
-                {
-                    expect( onMouseOver ).not.toBeCalled();
-                }
-            } );
-        } );
     } );
 
 
@@ -893,62 +669,6 @@ since it is read only';
 
             driver.mouseOut();
             expect( onMouseOut ).toBeCalledTimes( 1 );
-        } );
-
-
-        describe( 'isDisabled', () =>
-        {
-            test( 'throws the expected error when isDisabled', () =>
-            {
-                const expectedError =
-                    'InputField cannot simulate mouseOut since it is disabled';
-                wrapper.setProps( { isDisabled: true } );
-
-                expect( () => driver.mouseOut() ).toThrow( expectedError );
-            } );
-
-            test( 'should not trigger onMouseOut when isDisabled', () =>
-            {
-                const onMouseOut = jest.fn();
-                wrapper.setProps( { onMouseOut, isDisabled: true } );
-
-                try
-                {
-                    driver.mouseOut();
-                }
-                catch ( error )
-                {
-                    expect( onMouseOut ).not.toBeCalled();
-                }
-            } );
-        } );
-
-
-        describe( 'isReadOnly', () =>
-        {
-            test( 'throws the expected error when isReadOnly', () =>
-            {
-                const expectedError =
-                    'InputField cannot simulate mouseOut since it is read only';
-                wrapper.setProps( { isReadOnly: true } );
-
-                expect( () => driver.mouseOut() ).toThrow( expectedError );
-            } );
-
-            test( 'should not trigger onMouseOut when isReadOnly', () =>
-            {
-                const onMouseOut = jest.fn();
-                wrapper.setProps( { onMouseOut, isReadOnly: true } );
-
-                try
-                {
-                    driver.mouseOut();
-                }
-                catch ( error )
-                {
-                    expect( onMouseOut ).not.toBeCalled();
-                }
-            } );
         } );
     } );
 } );

--- a/src/PasswordInput/driver.js
+++ b/src/PasswordInput/driver.js
@@ -31,11 +31,6 @@ export default class PasswordInput
             throw new Error( ERR.PASS_ERR( label, 'blur', 'disabled' ) );
         }
 
-        if ( props.isReadOnly )
-        {
-            throw new Error( ERR.PASS_ERR( label, 'blur', 'read only' ) );
-        }
-
         this.wrapper.find( InputField ).driver().blur();
         return this;
     }
@@ -48,11 +43,6 @@ export default class PasswordInput
         if ( props.isDisabled )
         {
             throw new Error( ERR.PASS_ERR( label, 'focus', 'disabled' ) );
-        }
-
-        if ( props.isReadOnly )
-        {
-            throw new Error( ERR.PASS_ERR( label, 'focus', 'read only' ) );
         }
 
         this.wrapper.find( InputField ).driver().focus();
@@ -88,49 +78,18 @@ export default class PasswordInput
             throw new Error( ERR.PASS_ERR( label, 'keyPress', 'disabled' ) );
         }
 
-        if ( props.isReadOnly )
-        {
-            throw new Error( ERR.PASS_ERR( label, 'keyPress', 'read only' ) );
-        }
-
         this.wrapper.find( InputField ).driver().keyPress( keyCode );
         return this;
     }
 
     mouseOver()
     {
-        const props = this.wrapper.props();
-        const { label } = props;
-
-        if ( props.isDisabled )
-        {
-            throw new Error( ERR.PASS_ERR( label, 'mouseOver', 'disabled' ) );
-        }
-
-        if ( props.isReadOnly )
-        {
-            throw new Error( ERR.PASS_ERR( label, 'mouseOver', 'read only' ) );
-        }
-
         this.wrapper.simulate( 'mouseenter' );
         return this;
     }
 
     mouseOut()
     {
-        const props = this.wrapper.props();
-        const { label } = props;
-
-        if ( props.isDisabled )
-        {
-            throw new Error( ERR.PASS_ERR( label, 'mouseOut', 'disabled' ) );
-        }
-
-        if ( props.isReadOnly )
-        {
-            throw new Error( ERR.PASS_ERR( label, 'mouseOut', 'read only' ) );
-        }
-
         this.wrapper.simulate( 'mouseleave' );
         return this;
     }
@@ -145,53 +104,18 @@ export default class PasswordInput
             throw new Error( ERR.PASS_ERR( label, 'clickIcon', 'disabled' ) );
         }
 
-        if ( props.isReadOnly )
-        {
-            throw new Error( ERR.PASS_ERR( label, 'clickIcon', 'read only' ) );
-        }
-
         this.wrapper.find( IconButton ).simulate( 'click' );
         return this;
     }
 
     mouseOverIcon()
     {
-        const props = this.wrapper.props();
-        const { label } = props;
-
-        if ( props.isDisabled )
-        {
-            throw new Error( ERR
-                .PASS_ERR( label, 'mouseOverIcon', 'disabled' ) );
-        }
-
-        if ( props.isReadOnly )
-        {
-            throw new Error( ERR
-                .PASS_ERR( label, 'mouseOverIcon', 'read only' ) );
-        }
-
         this.wrapper.find( Tooltip ).driver().mouseOver();
         return this;
     }
 
     mouseOutIcon()
     {
-        const props = this.wrapper.props();
-        const { label } = props;
-
-        if ( props.isDisabled )
-        {
-            throw new Error( ERR
-                .PASS_ERR( label, 'mouseOutIcon', 'disabled' ) );
-        }
-
-        if ( props.isReadOnly )
-        {
-            throw new Error( ERR
-                .PASS_ERR( label, 'mouseOutIcon', 'read only' ) );
-        }
-
         this.wrapper.find( Tooltip ).driver().mouseOut();
         return this;
     }

--- a/src/PasswordInput/tests.jsx
+++ b/src/PasswordInput/tests.jsx
@@ -145,34 +145,6 @@ simulate focus since it is disabled';
                 }
             } );
         } );
-
-
-        describe( 'isReadOnly', () =>
-        {
-            test( 'throws the expected error when isReadOnly', () =>
-            {
-                const expectedError = 'PasswordInput \'Tekeli-li\' cannot \
-simulate focus since it is read only';
-                wrapper.setProps( { isReadOnly: true, label: 'Tekeli-li' } );
-
-                expect( () => driver.focus() ).toThrow( expectedError );
-            } );
-
-            test( 'should not trigger onFocus when isReadOnly', () =>
-            {
-                const onFocus = jest.fn();
-                wrapper.setProps( { onFocus, isReadOnly: true } );
-
-                try
-                {
-                    driver.focus();
-                }
-                catch ( error )
-                {
-                    expect( onFocus ).not.toBeCalled();
-                }
-            } );
-        } );
     } );
 
 
@@ -203,34 +175,6 @@ simulate blur since it is disabled';
             {
                 const onBlur = jest.fn();
                 wrapper.setProps( { onBlur, isDisabled: true } );
-
-                try
-                {
-                    driver.blur();
-                }
-                catch ( error )
-                {
-                    expect( onBlur ).not.toBeCalled();
-                }
-            } );
-        } );
-
-
-        describe( 'isReadOnly', () =>
-        {
-            test( 'throws the expected error when isReadOnly', () =>
-            {
-                const expectedError = 'PasswordInput \'Tekeli-li\' cannot \
-simulate blur since it is read only';
-                wrapper.setProps( { isReadOnly: true, label: 'Tekeli-li' } );
-
-                expect( () => driver.blur() ).toThrow( expectedError );
-            } );
-
-            test( 'should not trigger onBlur when isReadOnly', () =>
-            {
-                const onBlur = jest.fn();
-                wrapper.setProps( { onBlur, isReadOnly: true } );
 
                 try
                 {
@@ -356,34 +300,6 @@ simulate keyPress since it is disabled';
                 }
             } );
         } );
-
-
-        describe( 'isReadOnly', () =>
-        {
-            test( 'throws the expected error when isReadOnly', () =>
-            {
-                const expectedError = 'PasswordInput \'Tekeli-li\' cannot \
-simulate keyPress since it is read only';
-                wrapper.setProps( { isReadOnly: true, label: 'Tekeli-li' } );
-
-                expect( () => driver.keyPress() ).toThrow( expectedError );
-            } );
-
-            test( 'should not trigger onKeyPress when isReadOnly', () =>
-            {
-                const onKeyPress = jest.fn();
-                wrapper.setProps( { onKeyPress, isReadOnly: true } );
-
-                try
-                {
-                    driver.keyPress();
-                }
-                catch ( error )
-                {
-                    expect( onKeyPress ).not.toBeCalled();
-                }
-            } );
-        } );
     } );
 
 
@@ -397,62 +313,6 @@ simulate keyPress since it is read only';
             driver.mouseOver();
             expect( onMouseOver ).toBeCalledTimes( 1 );
         } );
-
-
-        describe( 'isDisabled', () =>
-        {
-            test( 'throws the expected error when isDisabled', () =>
-            {
-                const expectedError = 'PasswordInput \'Cthulhu\' cannot \
-simulate mouseOver since it is disabled';
-                wrapper.setProps( { isDisabled: true, label: 'Cthulhu' } );
-
-                expect( () => driver.mouseOver() ).toThrow( expectedError );
-            } );
-
-            test( 'should not trigger onMouseOver when isDisabled', () =>
-            {
-                const onMouseOver = jest.fn();
-                wrapper.setProps( { onMouseOver, isDisabled: true } );
-
-                try
-                {
-                    driver.mouseOver();
-                }
-                catch ( error )
-                {
-                    expect( onMouseOver ).not.toBeCalled();
-                }
-            } );
-        } );
-
-
-        describe( 'isReadOnly', () =>
-        {
-            test( 'throws the expected error when isReadOnly', () =>
-            {
-                const expectedError = 'PasswordInput \'Tekeli-li\' cannot \
-simulate mouseOver since it is read only';
-                wrapper.setProps( { isReadOnly: true, label: 'Tekeli-li' } );
-
-                expect( () => driver.mouseOver() ).toThrow( expectedError );
-            } );
-
-            test( 'should not trigger onMouseOver when isReadOnly', () =>
-            {
-                const onMouseOver = jest.fn();
-                wrapper.setProps( { onMouseOver, isReadOnly: true } );
-
-                try
-                {
-                    driver.mouseOver();
-                }
-                catch ( error )
-                {
-                    expect( onMouseOver ).not.toBeCalled();
-                }
-            } );
-        } );
     } );
 
 
@@ -465,62 +325,6 @@ simulate mouseOver since it is read only';
 
             driver.mouseOut();
             expect( onMouseOut ).toBeCalledTimes( 1 );
-        } );
-
-
-        describe( 'isDisabled', () =>
-        {
-            test( 'throws the expected error when isDisabled', () =>
-            {
-                const expectedError = 'PasswordInput \'Cthulhu\' cannot \
-simulate mouseOut since it is disabled';
-                wrapper.setProps( { isDisabled: true, label: 'Cthulhu' } );
-
-                expect( () => driver.mouseOut() ).toThrow( expectedError );
-            } );
-
-            test( 'should not trigger onMouseOut when isDisabled', () =>
-            {
-                const onMouseOut = jest.fn();
-                wrapper.setProps( { onMouseOut, isDisabled: true } );
-
-                try
-                {
-                    driver.mouseOut();
-                }
-                catch ( error )
-                {
-                    expect( onMouseOut ).not.toBeCalled();
-                }
-            } );
-        } );
-
-
-        describe( 'isReadOnly', () =>
-        {
-            test( 'throws the expected error when isReadOnly', () =>
-            {
-                const expectedError = 'PasswordInput \'Tekeli-li\' cannot \
-simulate mouseOut since it is read only';
-                wrapper.setProps( { isReadOnly: true, label: 'Tekeli-li' } );
-
-                expect( () => driver.mouseOut() ).toThrow( expectedError );
-            } );
-
-            test( 'should not trigger onMouseOut when isReadOnly', () =>
-            {
-                const onMouseOut = jest.fn();
-                wrapper.setProps( { onMouseOut, isReadOnly: true } );
-
-                try
-                {
-                    driver.mouseOut();
-                }
-                catch ( error )
-                {
-                    expect( onMouseOut ).not.toBeCalled();
-                }
-            } );
         } );
     } );
 
@@ -565,34 +369,6 @@ simulate clickIcon since it is disabled';
                 }
             } );
         } );
-
-
-        describe( 'isReadOnly', () =>
-        {
-            test( 'throws the expected error when isReadOnly', () =>
-            {
-                const expectedError = 'PasswordInput \'Tekeli-li\' cannot \
-simulate clickIcon since it is read only';
-                wrapper.setProps( { isReadOnly: true, label: 'Tekeli-li' } );
-
-                expect( () => driver.clickIcon() ).toThrow( expectedError );
-            } );
-
-            test( 'should not trigger onClickIcon when isReadOnly', () =>
-            {
-                const onClickIcon = jest.fn();
-                wrapper.setProps( { onClickIcon, isReadOnly: true } );
-
-                try
-                {
-                    driver.clickIcon();
-                }
-                catch ( error )
-                {
-                    expect( onClickIcon ).not.toBeCalled();
-                }
-            } );
-        } );
     } );
 
 
@@ -606,62 +382,6 @@ simulate clickIcon since it is read only';
             driver.mouseOverIcon();
             expect( onMouseOverIcon ).toBeCalledTimes( 1 );
         } );
-
-
-        describe( 'isDisabled', () =>
-        {
-            test( 'throws the expected error when isDisabled', () =>
-            {
-                const expectedError = 'PasswordInput \'Cthulhu\' cannot \
-simulate mouseOverIcon since it is disabled';
-                wrapper.setProps( { isDisabled: true, label: 'Cthulhu' } );
-
-                expect( () => driver.mouseOverIcon() ).toThrow( expectedError );
-            } );
-
-            test( 'should not trigger onMouseOverIcon when isDisabled', () =>
-            {
-                const onMouseOverIcon = jest.fn();
-                wrapper.setProps( { onMouseOverIcon, isDisabled: true } );
-
-                try
-                {
-                    driver.mouseOverIcon();
-                }
-                catch ( error )
-                {
-                    expect( onMouseOverIcon ).not.toBeCalled();
-                }
-            } );
-        } );
-
-
-        describe( 'isReadOnly', () =>
-        {
-            test( 'throws the expected error when isReadOnly', () =>
-            {
-                const expectedError = 'PasswordInput \'Tekeli-li\' cannot \
-simulate mouseOverIcon since it is read only';
-                wrapper.setProps( { isReadOnly: true, label: 'Tekeli-li' } );
-
-                expect( () => driver.mouseOverIcon() ).toThrow( expectedError );
-            } );
-
-            test( 'should not trigger onMouseOverIcon when isReadOnly', () =>
-            {
-                const onMouseOverIcon = jest.fn();
-                wrapper.setProps( { onMouseOverIcon, isReadOnly: true } );
-
-                try
-                {
-                    driver.mouseOverIcon();
-                }
-                catch ( error )
-                {
-                    expect( onMouseOverIcon ).not.toBeCalled();
-                }
-            } );
-        } );
     } );
 
 
@@ -674,62 +394,6 @@ simulate mouseOverIcon since it is read only';
 
             driver.mouseOutIcon();
             expect( onMouseOutIcon ).toBeCalledTimes( 1 );
-        } );
-
-
-        describe( 'isDisabled', () =>
-        {
-            test( 'throws the expected error when isDisabled', () =>
-            {
-                const expectedError = 'PasswordInput \'Cthulhu\' cannot \
-simulate mouseOutIcon since it is disabled';
-                wrapper.setProps( { isDisabled: true, label: 'Cthulhu' } );
-
-                expect( () => driver.mouseOutIcon() ).toThrow( expectedError );
-            } );
-
-            test( 'should not trigger onMouseOutIcon when isDisabled', () =>
-            {
-                const onMouseOutIcon = jest.fn();
-                wrapper.setProps( { onMouseOutIcon, isDisabled: true } );
-
-                try
-                {
-                    driver.mouseOutIcon();
-                }
-                catch ( error )
-                {
-                    expect( onMouseOutIcon ).not.toBeCalled();
-                }
-            } );
-        } );
-
-
-        describe( 'isReadOnly', () =>
-        {
-            test( 'throws the expected error when isReadOnly', () =>
-            {
-                const expectedError = 'PasswordInput \'Tekeli-li\' cannot \
-simulate mouseOutIcon since it is read only';
-                wrapper.setProps( { isReadOnly: true, label: 'Tekeli-li' } );
-
-                expect( () => driver.mouseOutIcon() ).toThrow( expectedError );
-            } );
-
-            test( 'should not trigger onMouseOutIcon when isReadOnly', () =>
-            {
-                const onMouseOutIcon = jest.fn();
-                wrapper.setProps( { onMouseOutIcon, isReadOnly: true } );
-
-                try
-                {
-                    driver.mouseOutIcon();
-                }
-                catch ( error )
-                {
-                    expect( onMouseOutIcon ).not.toBeCalled();
-                }
-            } );
         } );
     } );
 } );

--- a/src/Radio/driver.js
+++ b/src/Radio/driver.js
@@ -97,28 +97,12 @@ export default class RadioDriver
 
     mouseOver()
     {
-        const props     = this.wrapper.props();
-        const { label } = props;
-
-        if ( props.isDisabled )
-        {
-            throw new Error( ERR.RADIO_ERR( label, 'mouseOver', 'disabled' ) );
-        }
-
         this.wrapper.simulate( 'mouseenter' );
         return this;
     }
 
     mouseOut()
     {
-        const props     = this.wrapper.props();
-        const { label } = props;
-
-        if ( props.isDisabled )
-        {
-            throw new Error( ERR.RADIO_ERR( label, 'mouseOut', 'disabled' ) );
-        }
-
         this.wrapper.simulate( 'mouseleave' );
         return this;
     }

--- a/src/Radio/tests.jsx
+++ b/src/Radio/tests.jsx
@@ -128,7 +128,6 @@ describe( 'RadioDriver', () =>
             wrapper.setProps( { onBlur } );
 
             driver.blur();
-
             expect( onBlur ).toBeCalledTimes( 1 );
         } );
 
@@ -137,10 +136,9 @@ describe( 'RadioDriver', () =>
         {
             test( 'throws the expected error when isDisabled', () =>
             {
-                wrapper.setProps( { isDisabled: true, label: 'Tekeli-li' } );
-
                 const expectedError = 'Radio \'Tekeli-li\' cannot simulate \
 blur since it is disabled';
+                wrapper.setProps( { isDisabled: true, label: 'Tekeli-li' } );
 
                 expect( () => driver.blur() ).toThrow( expectedError );
             } );
@@ -170,10 +168,9 @@ blur since it is disabled';
         {
             test( 'throws the expected error when isReadOnly', () =>
             {
-                wrapper.setProps( { isReadOnly: true, label: 'Tekeli-li' } );
-
                 const expectedError = 'Radio \'Tekeli-li\' cannot simulate \
 blur since it is read only';
+                wrapper.setProps( { isReadOnly: true, label: 'Tekeli-li' } );
 
                 expect( () => driver.blur() ).toThrow( expectedError );
             } );
@@ -208,7 +205,6 @@ blur since it is read only';
             wrapper.setProps( { onFocus } );
 
             driver.focus();
-
             expect( onFocus ).toBeCalledTimes( 1 );
         } );
 
@@ -217,10 +213,9 @@ blur since it is read only';
         {
             test( 'throws the expected error when isDisabled', () =>
             {
-                wrapper.setProps( { isDisabled: true, label: 'Tekeli-li' } );
-
                 const expectedError = 'Radio \'Tekeli-li\' cannot simulate \
 focus since it is disabled';
+                wrapper.setProps( { isDisabled: true, label: 'Tekeli-li' } );
 
                 expect( () => driver.focus() ).toThrow( expectedError );
             } );
@@ -250,10 +245,9 @@ focus since it is disabled';
         {
             test( 'throws the expected error when isReadOnly', () =>
             {
-                wrapper.setProps( { isReadOnly: true, label: 'Tekeli-li' } );
-
                 const expectedError = 'Radio \'Tekeli-li\' cannot simulate \
 focus since it is read only';
+                wrapper.setProps( { isReadOnly: true, label: 'Tekeli-li' } );
 
                 expect( () => driver.focus() ).toThrow( expectedError );
             } );
@@ -288,7 +282,6 @@ focus since it is read only';
             wrapper.setProps( { onChange } );
 
             driver.change();
-
             expect( onChange ).toBeCalledTimes( 1 );
         } );
 
@@ -317,10 +310,9 @@ focus since it is read only';
         {
             test( 'throws the expected error when isDisabled', () =>
             {
-                wrapper.setProps( { isDisabled: true, label: 'Tekeli-li' } );
-
                 const expectedError = 'Radio \'Tekeli-li\' cannot simulate \
 change since it is disabled';
+                wrapper.setProps( { isDisabled: true, label: 'Tekeli-li' } );
 
                 expect( () => driver.change() ).toThrow( expectedError );
             } );
@@ -350,10 +342,9 @@ change since it is disabled';
         {
             test( 'throws the expected error when isReadOnly', () =>
             {
-                wrapper.setProps( { isReadOnly: true, label: 'Tekeli-li' } );
-
                 const expectedError = 'Radio \'Tekeli-li\' cannot simulate \
 change since it is read only';
+                wrapper.setProps( { isReadOnly: true, label: 'Tekeli-li' } );
 
                 expect( () => driver.change() ).toThrow( expectedError );
             } );
@@ -361,7 +352,6 @@ change since it is read only';
             test( 'should not trigger onChange when isReadOnly', () =>
             {
                 const onChange = jest.fn();
-
                 wrapper.setProps( {
                     isReadOnly : true,
                     label      : 'Tekeli-li',
@@ -398,10 +388,9 @@ change since it is read only';
         {
             test( 'throws the expected error when isDisabled', () =>
             {
-                wrapper.setProps( { isDisabled: true, label: 'Tekeli-li' } );
-
                 const expectedError = 'Radio \'Tekeli-li\' cannot simulate \
 click since it is disabled';
+                wrapper.setProps( { isDisabled: true, label: 'Tekeli-li' } );
 
                 expect( () => driver.click() ).toThrow( expectedError );
             } );
@@ -470,31 +459,7 @@ click since it is read only';
             wrapper.setProps( { onMouseOver } );
 
             driver.mouseOver();
-
             expect( onMouseOver ).toBeCalledTimes( 1 );
-        } );
-
-        test( 'throws the expected error when isDisabled', () =>
-        {
-            wrapper.setProps( { isDisabled: true, label: 'Tekeli-li' } );
-
-            const expectedError = 'Radio \'Tekeli-li\' cannot simulate \
-mouseOut since it is disabled';
-
-            expect( () => driver.mouseOut() ).toThrow( expectedError );
-        } );
-
-        test( 'should not trigger onMouseOver when isDisabled', () =>
-        {
-            const onMouseOver = jest.fn();
-            wrapper.setProps( {
-                isDisabled : true,
-                label      : 'Tekeli-li',
-                onMouseOver,
-            } );
-
-            expect( () => driver.mouseOut() );
-            expect( onMouseOver ).not.toBeCalled();
         } );
     } );
 
@@ -507,35 +472,7 @@ mouseOut since it is disabled';
             wrapper.setProps( { onMouseOut } );
 
             driver.mouseOut();
-
             expect( onMouseOut ).toBeCalledTimes( 1 );
-        } );
-
-
-        describe( 'isDisabled', () =>
-        {
-            test( 'throws the expected error when isDisabled', () =>
-            {
-                wrapper.setProps( { isDisabled: true, label: 'Tekeli-li' } );
-
-                const expectedError = 'Radio \'Tekeli-li\' cannot simulate \
-mouseOut since it is disabled';
-
-                expect( () => driver.mouseOut() ).toThrow( expectedError );
-            } );
-
-            test( 'should not trigger onMouseOut when isDisabled', () =>
-            {
-                const onMouseOut = jest.fn();
-                wrapper.setProps( {
-                    isDisabled : true,
-                    label      : 'Tekeli-li',
-                    onMouseOut,
-                } );
-
-                expect( () => driver.mouseOut() );
-                expect( onMouseOut ).not.toBeCalled();
-            } );
         } );
     } );
 } );

--- a/src/TagInput/driver.js
+++ b/src/TagInput/driver.js
@@ -46,11 +46,6 @@ export default class TagInputDriver
             throw new Error( ERR.TAGINPUT_ERR( 'blur', 'disabled' ) );
         }
 
-        if ( this.wrapper.props().isReadOnly )
-        {
-            throw new Error( ERR.TAGINPUT_ERR( 'blur', 'read only' ) );
-        }
-
         this.wrapper.find( `.${this.wrapper.props().cssMap.input}` )
             .simulate( 'blur' );
         return this;
@@ -80,11 +75,6 @@ export default class TagInputDriver
             throw new Error( ERR.TAGINPUT_ERR( 'focus', 'disabled' ) );
         }
 
-        if ( this.wrapper.props().isReadOnly )
-        {
-            throw new Error( ERR.TAGINPUT_ERR( 'focus', 'read only' ) );
-        }
-
         this.wrapper.find( `.${this.wrapper.props().cssMap.input}` )
             .simulate( 'focus' );
         return this;
@@ -95,11 +85,6 @@ export default class TagInputDriver
         if ( this.wrapper.props().isDisabled )
         {
             throw new Error( ERR.TAGINPUT_ERR( 'keyPress', 'disabled' ) );
-        }
-
-        if ( this.wrapper.props().isReadOnly )
-        {
-            throw new Error( ERR.TAGINPUT_ERR( 'keyPress', 'read only' ) );
         }
 
         this.wrapper.find( `.${this.wrapper.props().cssMap.input}` )
@@ -114,11 +99,6 @@ export default class TagInputDriver
             throw new Error( ERR.TAGINPUT_ERR( 'keyDown', 'disabled' ) );
         }
 
-        if ( this.wrapper.props().isReadOnly )
-        {
-            throw new Error( ERR.TAGINPUT_ERR( 'keyDown', 'read only' ) );
-        }
-
         this.wrapper.find( `.${this.wrapper.props().cssMap.input}` )
             .simulate( 'keyDown', { keyCode } );
         return this;
@@ -131,11 +111,6 @@ export default class TagInputDriver
             throw new Error( ERR.TAGINPUT_ERR( 'keyUp', 'disabled' ) );
         }
 
-        if ( this.wrapper.props().isReadOnly )
-        {
-            throw new Error( ERR.TAGINPUT_ERR( 'keyUp', 'read only' ) );
-        }
-
         this.wrapper.find( `.${this.wrapper.props().cssMap.input}` )
             .simulate( 'keyUp', { keyCode } );
         return this;
@@ -143,22 +118,12 @@ export default class TagInputDriver
 
     mouseOver()
     {
-        if ( this.wrapper.props().isDisabled )
-        {
-            throw new Error( ERR.TAGINPUT_ERR( 'mouseOver', 'disabled' ) );
-        }
-
         this.wrapper.simulate( 'mouseenter' );
         return this;
     }
 
     mouseOut()
     {
-        if ( this.wrapper.props().isDisabled )
-        {
-            throw new Error( ERR.TAGINPUT_ERR( 'mouseOut', 'disabled' ) );
-        }
-
         this.wrapper.simulate( 'mouseleave' );
         return this;
     }

--- a/src/TagInput/tests.jsx
+++ b/src/TagInput/tests.jsx
@@ -153,34 +153,6 @@ describe( 'TagInputDriver', () =>
                 }
             } );
         } );
-
-
-        describe( 'isReadOnly', () =>
-        {
-            test( 'throws the expected error when isReadOnly', () =>
-            {
-                const expectedError =
-                    'TagInput cannot simulate blur since it is read only';
-                wrapper.setProps( { isReadOnly: true } );
-
-                expect( () => driver.blur() ).toThrow( expectedError );
-            } );
-
-            test( 'should not trigger onBlur when isReadOnly', () =>
-            {
-                const onBlur = jest.fn();
-                wrapper.setProps( { onBlur, isReadOnly: true } );
-
-                try
-                {
-                    driver.blur();
-                }
-                catch ( error )
-                {
-                    expect( onBlur ).not.toBeCalled();
-                }
-            } );
-        } );
     } );
 
 
@@ -217,34 +189,6 @@ describe( 'TagInputDriver', () =>
             {
                 const onFocus = jest.fn();
                 wrapper.setProps( { onFocus, isDisabled: true } );
-
-                try
-                {
-                    driver.focus();
-                }
-                catch ( error )
-                {
-                    expect( onFocus ).not.toBeCalled();
-                }
-            } );
-        } );
-
-
-        describe( 'isReadOnly', () =>
-        {
-            test( 'throws the expected error when isReadOnly', () =>
-            {
-                const expectedError =
-                    'TagInput cannot simulate focus since it is read only';
-                wrapper.setProps( { isReadOnly: true } );
-
-                expect( () => driver.focus() ).toThrow( expectedError );
-            } );
-
-            test( 'should not trigger onFocus when isReadOnly', () =>
-            {
-                const onFocus = jest.fn();
-                wrapper.setProps( { onFocus, isReadOnly: true } );
 
                 try
                 {
@@ -455,34 +399,6 @@ describe( 'TagInputDriver', () =>
                 }
             } );
         } );
-
-
-        describe( 'isReadOnly', () =>
-        {
-            test( 'throws the expected error when isReadOnly', () =>
-            {
-                const expectedError =
-                    'TagInput cannot simulate keyPress since it is read only';
-                wrapper.setProps( { isReadOnly: true } );
-
-                expect( () => driver.keyPress() ).toThrow( expectedError );
-            } );
-
-            test( 'should not trigger onKeyPress when isReadOnly', () =>
-            {
-                const onKeyPress = jest.fn();
-                wrapper.setProps( { onKeyPress, isReadOnly: true } );
-
-                try
-                {
-                    driver.keyPress();
-                }
-                catch ( error )
-                {
-                    expect( onKeyPress ).not.toBeCalled();
-                }
-            } );
-        } );
     } );
 
 
@@ -519,34 +435,6 @@ describe( 'TagInputDriver', () =>
             {
                 const onKeyUp = jest.fn();
                 wrapper.setProps( { onKeyUp, isDisabled: true } );
-
-                try
-                {
-                    driver.keyUp();
-                }
-                catch ( error )
-                {
-                    expect( onKeyUp ).not.toBeCalled();
-                }
-            } );
-        } );
-
-
-        describe( 'isReadOnly', () =>
-        {
-            test( 'throws the expected error when isReadOnly', () =>
-            {
-                const expectedError =
-                    'TagInput cannot simulate keyUp since it is read only';
-                wrapper.setProps( { isReadOnly: true } );
-
-                expect( () => driver.keyUp() ).toThrow( expectedError );
-            } );
-
-            test( 'should not trigger onKeyUp when isReadOnly', () =>
-            {
-                const onKeyUp = jest.fn();
-                wrapper.setProps( { onKeyUp, isReadOnly: true } );
 
                 try
                 {
@@ -605,34 +493,6 @@ describe( 'TagInputDriver', () =>
                 }
             } );
         } );
-
-
-        describe( 'isReadOnly', () =>
-        {
-            test( 'throws the expected error when isReadOnly', () =>
-            {
-                const expectedError =
-                    'TagInput cannot simulate keyDown since it is read only';
-                wrapper.setProps( { isReadOnly: true } );
-
-                expect( () => driver.keyDown() ).toThrow( expectedError );
-            } );
-
-            test( 'should not trigger onKeyDown when isReadOnly', () =>
-            {
-                const onKeyDown = jest.fn();
-                wrapper.setProps( { onKeyDown, isReadOnly: true } );
-
-                try
-                {
-                    driver.keyDown();
-                }
-                catch ( error )
-                {
-                    expect( onKeyDown ).not.toBeCalled();
-                }
-            } );
-        } );
     } );
 
 
@@ -652,34 +512,6 @@ describe( 'TagInputDriver', () =>
             driver.mouseOut();
             expect( onMouseOut ).toBeCalledTimes( 1 );
         } );
-
-
-        describe( 'isDisabled', () =>
-        {
-            test( 'throws the expected error when isDisabled', () =>
-            {
-                const expectedError =
-                    'TagInput cannot simulate mouseOut since it is disabled';
-                wrapper.setProps( { isDisabled: true } );
-
-                expect( () => driver.mouseOut() ).toThrow( expectedError );
-            } );
-
-            test( 'should not trigger onMouseOut when isDisabled', () =>
-            {
-                const onMouseOut = jest.fn();
-                wrapper.setProps( { onMouseOut, isDisabled: true } );
-
-                try
-                {
-                    driver.mouseOut();
-                }
-                catch ( error )
-                {
-                    expect( onMouseOut ).not.toBeCalled();
-                }
-            } );
-        } );
     } );
 
 
@@ -698,34 +530,6 @@ describe( 'TagInputDriver', () =>
 
             driver.mouseOver();
             expect( onMouseOver ).toBeCalledTimes( 1 );
-        } );
-
-
-        describe( 'isDisabled', () =>
-        {
-            test( 'throws the expected error when isDisabled', () =>
-            {
-                const expectedError =
-                    'TagInput cannot simulate mouseOver since it is disabled';
-                wrapper.setProps( { isDisabled: true } );
-
-                expect( () => driver.mouseOver() ).toThrow( expectedError );
-            } );
-
-            test( 'should not trigger onMouseOver when isDisabled', () =>
-            {
-                const onMouseOver = jest.fn();
-                wrapper.setProps( { onMouseOver, isDisabled: true } );
-
-                try
-                {
-                    driver.mouseOver();
-                }
-                catch ( error )
-                {
-                    expect( onMouseOver ).not.toBeCalled();
-                }
-            } );
         } );
     } );
 } );

--- a/src/TextArea/driver.js
+++ b/src/TextArea/driver.js
@@ -28,11 +28,6 @@ export default class TextAreaDriver
             throw new Error( ERR.TEXTAREA_ERR( 'blur', 'disabled' ) );
         }
 
-        if ( this.wrapper.props().isReadOnly )
-        {
-            throw new Error( ERR.TEXTAREA_ERR( 'blur', 'read only' ) );
-        }
-
         this.wrapper.find( InputField ).driver().blur();
         return this;
     }
@@ -74,11 +69,6 @@ export default class TextAreaDriver
         if ( this.wrapper.props().isDisabled )
         {
             throw new Error( ERR.TEXTAREA_ERR( 'focus', 'disabled' ) );
-        }
-
-        if ( this.wrapper.props().isReadOnly )
-        {
-            throw new Error( ERR.TEXTAREA_ERR( 'focus', 'read only' ) );
         }
 
         this.wrapper.find( InputField ).driver().focus();

--- a/src/TextArea/tests.jsx
+++ b/src/TextArea/tests.jsx
@@ -102,34 +102,6 @@ describe( 'TextAreaDriver', () =>
                 }
             } );
         } );
-
-
-        describe( 'isReadOnly', () =>
-        {
-            test( 'throws the expected error when isReadOnly', () =>
-            {
-                const expectedError =
-                    'TextArea cannot simulate blur since it is read only';
-                wrapper.setProps( { isReadOnly: true } );
-
-                expect( () => driver.blur() ).toThrow( expectedError );
-            } );
-
-            test( 'should not trigger onBlur when isReadOnly', () =>
-            {
-                const onBlur = jest.fn();
-                wrapper.setProps( { onBlur, isReadOnly: true } );
-
-                try
-                {
-                    driver.blur();
-                }
-                catch ( error )
-                {
-                    expect( onBlur ).not.toBeCalled();
-                }
-            } );
-        } );
     } );
 
 
@@ -160,34 +132,6 @@ describe( 'TextAreaDriver', () =>
             {
                 const onFocus = jest.fn();
                 wrapper.setProps( { onFocus, isDisabled: true } );
-
-                try
-                {
-                    driver.focus();
-                }
-                catch ( error )
-                {
-                    expect( onFocus ).not.toBeCalled();
-                }
-            } );
-        } );
-
-
-        describe( 'isReadOnly', () =>
-        {
-            test( 'throws the expected error when isReadOnly', () =>
-            {
-                const expectedError =
-                    'TextArea cannot simulate focus since it is read only';
-                wrapper.setProps( { isReadOnly: true } );
-
-                expect( () => driver.focus() ).toThrow( expectedError );
-            } );
-
-            test( 'should not trigger onFocus when isReadOnly', () =>
-            {
-                const onFocus = jest.fn();
-                wrapper.setProps( { onFocus, isReadOnly: true } );
 
                 try
                 {

--- a/src/TextInput/driver.js
+++ b/src/TextInput/driver.js
@@ -19,11 +19,6 @@ export default class TextInputDriver
             throw new Error( ERR.TEXTINPUT_ERR( 'blur', 'disabled' ) );
         }
 
-        if ( this.wrapper.props().isReadOnly )
-        {
-            throw new Error( ERR.TEXTINPUT_ERR( 'blur', 'read only' ) );
-        }
-
         this.wrapper.find( InputField ).driver().blur();
         return this;
     }
@@ -33,11 +28,6 @@ export default class TextInputDriver
         if ( this.wrapper.props().isDisabled )
         {
             throw new Error( ERR.TEXTINPUT_ERR( 'click', 'disabled' ) );
-        }
-
-        if ( this.wrapper.props().isReadOnly )
-        {
-            throw new Error( ERR.TEXTINPUT_ERR( 'click', 'read only' ) );
         }
 
         this.wrapper.find( InputField ).driver().click();
@@ -65,11 +55,6 @@ export default class TextInputDriver
         if ( this.wrapper.props().isDisabled )
         {
             throw new Error( ERR.TEXTINPUT_ERR( 'focus', 'disabled' ) );
-        }
-
-        if ( this.wrapper.props().isReadOnly )
-        {
-            throw new Error( ERR.TEXTINPUT_ERR( 'focus', 'read only' ) );
         }
 
         this.wrapper.find( InputField ).driver().focus();

--- a/src/TextInput/tests.jsx
+++ b/src/TextInput/tests.jsx
@@ -74,10 +74,9 @@ describe( 'TextInputDriver', () =>
         {
             test( 'throws the expected error when isDisabled', () =>
             {
-                wrapper.setProps( { isDisabled: true } );
-
                 const expectedError =
                     'TextInput cannot simulate blur since it is disabled';
+                wrapper.setProps( { isDisabled: true } );
 
                 expect( () => driver.blur() ).toThrow( expectedError );
             } );
@@ -86,35 +85,6 @@ describe( 'TextInputDriver', () =>
             {
                 const onBlur = jest.fn();
                 wrapper.setProps( { onBlur, isDisabled: true } );
-
-                try
-                {
-                    driver.blur();
-                }
-                catch ( error )
-                {
-                    expect( onBlur ).not.toBeCalled();
-                }
-            } );
-        } );
-
-
-        describe( 'isReadOnly', () =>
-        {
-            test( 'throws the expected error when isReadOnly', () =>
-            {
-                wrapper.setProps( { isReadOnly: true } );
-
-                const expectedError =
-                    'TextInput cannot simulate blur since it is read only';
-
-                expect( () => driver.blur() ).toThrow( expectedError );
-            } );
-
-            test( 'should not trigger onBlur when isReadOnly', () =>
-            {
-                const onBlur = jest.fn();
-                wrapper.setProps( { onBlur, isReadOnly: true } );
 
                 try
                 {
@@ -145,10 +115,9 @@ describe( 'TextInputDriver', () =>
         {
             test( 'throws the expected error when isDisabled', () =>
             {
-                wrapper.setProps( { isDisabled: true } );
-
                 const expectedError =
                     'TextInput cannot simulate focus since it is disabled';
+                wrapper.setProps( { isDisabled: true } );
 
                 expect( () => driver.focus() ).toThrow( expectedError );
             } );
@@ -157,35 +126,6 @@ describe( 'TextInputDriver', () =>
             {
                 const onFocus = jest.fn();
                 wrapper.setProps( { onFocus, isDisabled: true } );
-
-                try
-                {
-                    driver.focus();
-                }
-                catch ( error )
-                {
-                    expect( onFocus ).not.toBeCalled();
-                }
-            } );
-        } );
-
-
-        describe( 'isReadOnly', () =>
-        {
-            test( 'throws the expected error when isReadOnly', () =>
-            {
-                wrapper.setProps( { isReadOnly: true } );
-
-                const expectedError =
-                    'TextInput cannot simulate focus since it is read only';
-
-                expect( () => driver.focus() ).toThrow( expectedError );
-            } );
-
-            test( 'should not trigger onFocus when isReadOnly', () =>
-            {
-                const onFocus = jest.fn();
-                wrapper.setProps( { onFocus, isReadOnly: true } );
 
                 try
                 {
@@ -216,10 +156,9 @@ describe( 'TextInputDriver', () =>
         {
             test( 'throws the expected error when isDisabled', () =>
             {
-                wrapper.setProps( { isDisabled: true } );
-
                 const expectedError =
                     'TextInput cannot simulate keyPress since it is disabled';
+                wrapper.setProps( { isDisabled: true } );
 
                 expect( () => driver.keyPress() ).toThrow( expectedError );
             } );
@@ -258,10 +197,9 @@ describe( 'TextInputDriver', () =>
         {
             test( 'throws the expected error when isDisabled', () =>
             {
-                wrapper.setProps( { isDisabled: true } );
-
                 const expectedError =
                     'TextInput cannot simulate change since it is disabled';
+                wrapper.setProps( { isDisabled: true } );
 
                 expect( () => driver.change() ).toThrow( expectedError );
             } );
@@ -287,10 +225,9 @@ describe( 'TextInputDriver', () =>
         {
             test( 'throws the expected error when isReadOnly', () =>
             {
-                wrapper.setProps( { isReadOnly: true } );
-
                 const expectedError =
                     'TextInput cannot simulate change since it is read only';
+                wrapper.setProps( { isReadOnly: true } );
 
                 expect( () => driver.change() ).toThrow( expectedError );
             } );
@@ -321,7 +258,6 @@ describe( 'TextInputDriver', () =>
             wrapper.setProps( { onClick } );
 
             driver.click();
-
             expect( onClick ).toBeCalledTimes( 1 );
         } );
 
@@ -330,10 +266,9 @@ describe( 'TextInputDriver', () =>
         {
             test( 'throws the expected error when isDisabled', () =>
             {
-                wrapper.setProps( { isDisabled: true } );
-
                 const expectedError =
                     'TextInput cannot simulate click since it is disabled';
+                wrapper.setProps( { isDisabled: true } );
 
                 expect( () => driver.click() ).toThrow( expectedError );
             } );
@@ -342,35 +277,6 @@ describe( 'TextInputDriver', () =>
             {
                 const onClick = jest.fn();
                 wrapper.setProps( { onClick, isDisabled: true } );
-
-                try
-                {
-                    driver.click();
-                }
-                catch ( error )
-                {
-                    expect( onClick ).not.toBeCalled();
-                }
-            } );
-        } );
-
-
-        describe( 'isReadOnly', () =>
-        {
-            test( 'throws the expected error when isReadOnly', () =>
-            {
-                wrapper.setProps( { isReadOnly: true } );
-
-                const expectedError =
-                    'TextInput cannot simulate click since it is read only';
-
-                expect( () => driver.click() ).toThrow( expectedError );
-            } );
-
-            test( 'should not trigger onClick when isReadOnly', () =>
-            {
-                const onClick = jest.fn();
-                wrapper.setProps( { onClick, isReadOnly: true } );
 
                 try
                 {

--- a/src/ToggleButton/driver.js
+++ b/src/ToggleButton/driver.js
@@ -23,18 +23,6 @@ export default class ToggleButtonDriver
                 .TOGGLEBUTTON_ERR( label, 'click', 'disabled' ) );
         }
 
-        if ( props.isReadOnly )
-        {
-            throw new Error( ERR
-                .TOGGLEBUTTON_ERR( label, 'click', 'read only' ) );
-        }
-
-        if ( props.isLoading )
-        {
-            throw new Error( ERR
-                .TOGGLEBUTTON_ERR( label, 'click', 'loading' ) );
-        }
-
         this.button.simulate( 'click' );
         return this;
     }
@@ -48,12 +36,6 @@ export default class ToggleButtonDriver
         {
             throw new Error( ERR
                 .TOGGLEBUTTON_ERR( label, 'mouseOver', 'disabled' ) );
-        }
-
-        if ( props.isLoading )
-        {
-            throw new Error( ERR
-                .TOGGLEBUTTON_ERR( label, 'mouseOver', 'loading' ) );
         }
 
         this.button.simulate( 'mouseenter' );
@@ -71,66 +53,18 @@ export default class ToggleButtonDriver
                 .TOGGLEBUTTON_ERR( label, 'mouseOut', 'disabled' ) );
         }
 
-        if ( props.isLoading )
-        {
-            throw new Error( ERR
-                .TOGGLEBUTTON_ERR( label, 'mouseOut', 'loading' ) );
-        }
-
         this.button.simulate( 'mouseleave' );
         return this;
     }
 
     focus()
     {
-        const props = this.wrapper.props();
-        const { label } = props;
-
-        if ( props.isDisabled )
-        {
-            throw new Error( ERR
-                .TOGGLEBUTTON_ERR( label, 'focus', 'disabled' ) );
-        }
-
-        if ( props.isReadOnly )
-        {
-            throw new Error( ERR
-                .TOGGLEBUTTON_ERR( label, 'focus', 'read only' ) );
-        }
-
-        if ( props.isLoading )
-        {
-            throw new Error( ERR
-                .TOGGLEBUTTON_ERR( label, 'focus', 'loading' ) );
-        }
-
         this.button.simulate( 'focus' );
         return this;
     }
 
     blur()
     {
-        const props = this.wrapper.props();
-        const { label } = props;
-
-        if ( props.isDisabled )
-        {
-            throw new Error( ERR
-                .TOGGLEBUTTON_ERR( label, 'blur', 'disabled' ) );
-        }
-
-        if ( props.isReadOnly )
-        {
-            throw new Error( ERR
-                .TOGGLEBUTTON_ERR( label, 'blur', 'read only' ) );
-        }
-
-        if ( props.isLoading )
-        {
-            throw new Error( ERR
-                .TOGGLEBUTTON_ERR( label, 'blur', 'loading' ) );
-        }
-
         this.button.simulate( 'blur' );
         return this;
     }

--- a/src/ToggleButton/tests.jsx
+++ b/src/ToggleButton/tests.jsx
@@ -234,34 +234,6 @@ simulate click since it is disabled';
                 }
             } );
         } );
-
-
-        describe( 'isReadOnly', () =>
-        {
-            test( 'throws the expected error when isReadOnly', () =>
-            {
-                const expectedError = 'ToggleButton \'Tekeli-li\' cannot \
-simulate click since it is read only';
-                wrapper.setProps( { isReadOnly: true, label: 'Tekeli-li' } );
-
-                expect( () => driver.click() ).toThrow( expectedError );
-            } );
-
-            test( 'should not trigger onClick when isReadOnly', () =>
-            {
-                const onClick = jest.fn();
-                wrapper.setProps( { onClick, isReadOnly: true } );
-
-                try
-                {
-                    driver.click();
-                }
-                catch ( error )
-                {
-                    expect( onClick ).not.toBeCalled();
-                }
-            } );
-        } );
     } );
 
 
@@ -322,10 +294,9 @@ simulate mouseOver since it is disabled';
         {
             test( 'throws the expected error when isDisabled', () =>
             {
-                wrapper.setProps( { isDisabled: true, label: 'Tekeli-li' } );
-
                 const expectedError = 'ToggleButton \'Tekeli-li\' cannot \
 simulate mouseOut since it is disabled';
+                wrapper.setProps( { isDisabled: true, label: 'Tekeli-li' } );
 
                 expect( () => driver.mouseOut() ).toThrow( expectedError );
             } );
@@ -358,64 +329,6 @@ simulate mouseOut since it is disabled';
             driver.blur();
             expect( onBlur ).toBeCalledTimes( 1 );
         } );
-
-
-        describe( 'isDisabled', () =>
-        {
-            test( 'throws the expected error when isDisabled', () =>
-            {
-                wrapper.setProps( { isDisabled: true, label: 'Tekeli-li' } );
-
-                const expectedError = 'ToggleButton \'Tekeli-li\' cannot \
-simulate blur since it is disabled';
-
-                expect( () => driver.blur() ).toThrow( expectedError );
-            } );
-
-            test( 'should not trigger onBlur when isDisabled', () =>
-            {
-                const onBlur = jest.fn();
-                wrapper.setProps( { onBlur, isDisabled: true } );
-
-                try
-                {
-                    driver.blur();
-                }
-                catch ( error )
-                {
-                    expect( onBlur ).not.toBeCalled();
-                }
-            } );
-        } );
-
-
-        describe( 'isReadOnly', () =>
-        {
-            test( 'throws the expected error when isReadOnly', () =>
-            {
-                wrapper.setProps( { isReadOnly: true, label: 'Tekeli-li' } );
-
-                const expectedError = 'ToggleButton \'Tekeli-li\' cannot \
-simulate blur since it is read only';
-
-                expect( () => driver.blur() ).toThrow( expectedError );
-            } );
-
-            test( 'should not trigger onBlur when isReadOnly', () =>
-            {
-                const onBlur = jest.fn();
-                wrapper.setProps( { onBlur, isReadOnly: true } );
-
-                try
-                {
-                    driver.blur();
-                }
-                catch ( error )
-                {
-                    expect( onBlur ).not.toBeCalled();
-                }
-            } );
-        } );
     } );
 
 
@@ -428,64 +341,6 @@ simulate blur since it is read only';
 
             driver.focus();
             expect( onFocus ).toBeCalledTimes( 1 );
-        } );
-
-
-        describe( 'isDisabled', () =>
-        {
-            test( 'throws the expected error when isDisabled', () =>
-            {
-                wrapper.setProps( { isDisabled: true, label: 'Tekeli-li' } );
-
-                const expectedError = 'ToggleButton \'Tekeli-li\' cannot \
-simulate focus since it is disabled';
-
-                expect( () => driver.focus() ).toThrow( expectedError );
-            } );
-
-            test( 'should not trigger onFocus when isDisabled', () =>
-            {
-                const onFocus = jest.fn();
-                wrapper.setProps( { onFocus, isDisabled: true } );
-
-                try
-                {
-                    driver.focus();
-                }
-                catch ( error )
-                {
-                    expect( onFocus ).not.toBeCalled();
-                }
-            } );
-        } );
-
-
-        describe( 'isReadOnly', () =>
-        {
-            test( 'throws the expected error when isReadOnly', () =>
-            {
-                wrapper.setProps( { isReadOnly: true, label: 'Tekeli-li' } );
-
-                const expectedError = 'ToggleButton \'Tekeli-li\' cannot \
-simulate focus since it is read only';
-
-                expect( () => driver.focus() ).toThrow( expectedError );
-            } );
-
-            test( 'should not trigger onFocus when isReadOnly', () =>
-            {
-                const onFocus = jest.fn();
-                wrapper.setProps( { onFocus, isReadOnly: true } );
-
-                try
-                {
-                    driver.focus();
-                }
-                catch ( error )
-                {
-                    expect( onFocus ).not.toBeCalled();
-                }
-            } );
         } );
     } );
 } );

--- a/src/ValuedTextInput/driver.js
+++ b/src/ValuedTextInput/driver.js
@@ -19,11 +19,6 @@ export default class ValuedTextInputDriver
             throw new Error( ERR.VALUEDTEXTINPUT_ERR( 'blur', 'disabled' ) );
         }
 
-        if ( this.wrapper.props().isReadOnly )
-        {
-            throw new Error( ERR.VALUEDTEXTINPUT_ERR( 'blur', 'read only' ) );
-        }
-
         this.wrapper.find( InputField ).driver().blur();
         return this;
     }
@@ -33,11 +28,6 @@ export default class ValuedTextInputDriver
         if ( this.wrapper.props().isDisabled )
         {
             throw new Error( ERR.VALUEDTEXTINPUT_ERR( 'click', 'disabled' ) );
-        }
-
-        if ( this.wrapper.props().isReadOnly )
-        {
-            throw new Error( ERR.VALUEDTEXTINPUT_ERR( 'click', 'read only' ) );
         }
 
         this.wrapper.find( InputField ).driver().click();
@@ -65,11 +55,6 @@ export default class ValuedTextInputDriver
         if ( this.wrapper.props().isDisabled )
         {
             throw new Error( ERR.VALUEDTEXTINPUT_ERR( 'focus', 'disabled' ) );
-        }
-
-        if ( this.wrapper.props().isReadOnly )
-        {
-            throw new Error( ERR.VALUEDTEXTINPUT_ERR( 'focus', 'read only' ) );
         }
 
         this.wrapper.find( InputField ).driver().focus();

--- a/src/ValuedTextInput/tests.jsx
+++ b/src/ValuedTextInput/tests.jsx
@@ -103,34 +103,6 @@ describe( 'ValuedTextInputDriver', () =>
                 }
             } );
         } );
-
-
-        describe( 'isReadOnly', () =>
-        {
-            test( 'throws the expected error when isReadOnly', () =>
-            {
-                const expectedError = 'ValuedTextInput cannot simulate blur \
-since it is read only';
-                wrapper.setProps( { isReadOnly: true } );
-
-                expect( () => driver.blur() ).toThrow( expectedError );
-            } );
-
-            test( 'should not trigger onBlur when isReadOnly', () =>
-            {
-                const onBlur = jest.fn();
-                wrapper.setProps( { onBlur, isReadOnly: true } );
-
-                try
-                {
-                    driver.blur();
-                }
-                catch ( error )
-                {
-                    expect( onBlur ).not.toBeCalled();
-                }
-            } );
-        } );
     } );
 
 
@@ -161,34 +133,6 @@ since it is disabled';
             {
                 const onFocus = jest.fn();
                 wrapper.setProps( { onFocus, isDisabled: true } );
-
-                try
-                {
-                    driver.focus();
-                }
-                catch ( error )
-                {
-                    expect( onFocus ).not.toBeCalled();
-                }
-            } );
-        } );
-
-
-        describe( 'isReadOnly', () =>
-        {
-            test( 'throws the expected error when isReadOnly', () =>
-            {
-                const expectedError = 'ValuedTextInput cannot simulate focus \
-since it is read only';
-                wrapper.setProps( { isReadOnly: true } );
-
-                expect( () => driver.focus() ).toThrow( expectedError );
-            } );
-
-            test( 'should not trigger onFocus when isReadOnly', () =>
-            {
-                const onFocus = jest.fn();
-                wrapper.setProps( { onFocus, isReadOnly: true } );
 
                 try
                 {
@@ -340,34 +284,6 @@ since it is disabled';
             {
                 const onClick = jest.fn();
                 wrapper.setProps( { onClick, isDisabled: true } );
-
-                try
-                {
-                    driver.click();
-                }
-                catch ( error )
-                {
-                    expect( onClick ).not.toBeCalled();
-                }
-            } );
-        } );
-
-
-        describe( 'isReadOnly', () =>
-        {
-            test( 'throws the expected error when isReadOnly', () =>
-            {
-                const expectedError = 'ValuedTextInput cannot simulate click \
-since it is read only';
-                wrapper.setProps( { isReadOnly: true } );
-
-                expect( () => driver.click() ).toThrow( expectedError );
-            } );
-
-            test( 'should not trigger onClick when isReadOnly', () =>
-            {
-                const onClick = jest.fn();
-                wrapper.setProps( { onClick, isReadOnly: true } );
 
                 try
                 {

--- a/src/proto/InputContainer.jsx
+++ b/src/proto/InputContainer.jsx
@@ -98,31 +98,31 @@ InputContainer.propTypes = {
     /**
      *  Whether error icon is shown
      */
-    hasError              : PropTypes.bool,
+    hasError      : PropTypes.bool,
     /**
      *  id of the associated input
      */
-    id                    : PropTypes.string,
+    id            : PropTypes.string,
     /**
      *  Display as disabled
      */
-    isDisabled            : PropTypes.bool,
+    isDisabled    : PropTypes.bool,
     /**
      *  Input label text
      */
-    label                 : PropTypes.node,
+    label         : PropTypes.node,
     /**
      *  Label position relative to the input
      */
-    labelPosition         : PropTypes.oneOf( [ 'top', 'left', 'right' ] ),
+    labelPosition : PropTypes.oneOf( [ 'top', 'left', 'right' ] ),
     /**
      *  Mouse over callback function
      */
-    onMouseOut            : PropTypes.func,
+    onMouseOut    : PropTypes.func,
     /**
      *  Mouse out callback function
      */
-    onMouseOver           : PropTypes.func,
+    onMouseOver   : PropTypes.func,
 };
 
 InputContainer.defaultProps = {


### PR DESCRIPTION
For #698:

- removed errors for `onEvent` that triggers if component has `isReadOnly` and/or `isDisabled`
- updated tests accordingly
- minor linter fixes