### PR TITLE
[DateTimeInput] added onChange driver and tests

### DIFF
--- a/src/DatePicker/driver.js
+++ b/src/DatePicker/driver.js
@@ -69,7 +69,7 @@ export default class DatePickerDriver
         return this;
     }
 
-    keyPressHour( key )
+    keyPressHourInput( key )
     {
         if ( this.wrapper.props().mode !== 'default' )
         {
@@ -85,7 +85,7 @@ export default class DatePickerDriver
         return this;
     }
 
-    keyPressMinute( key )
+    keyPressMinuteInput( key )
     {
         if ( this.wrapper.props().mode !== 'default' )
         {
@@ -101,7 +101,7 @@ export default class DatePickerDriver
         return this;
     }
 
-    blurHour()
+    blurHourInput()
     {
         if ( this.wrapper.props().mode !== 'default' )
         {
@@ -117,7 +117,7 @@ export default class DatePickerDriver
         return this;
     }
 
-    blurMinute()
+    blurMinuteInput()
     {
         if ( this.wrapper.props().mode !== 'default' )
         {
@@ -133,7 +133,7 @@ export default class DatePickerDriver
         return this;
     }
 
-    focusHour()
+    focusHourInput()
     {
         if ( this.wrapper.props().mode !== 'default' )
         {
@@ -149,7 +149,7 @@ export default class DatePickerDriver
         return this;
     }
 
-    focusMinute()
+    focusMinuteInput()
     {
         if ( this.wrapper.props().mode !== 'default' )
         {
@@ -165,7 +165,7 @@ export default class DatePickerDriver
         return this;
     }
 
-    changeHour( val )
+    changeHourInput( val )
     {
         if ( this.wrapper.props().mode !== 'default' )
         {
@@ -189,7 +189,7 @@ export default class DatePickerDriver
         return this;
     }
 
-    changeMinute( val )
+    changeMinuteInput( val )
     {
         if ( this.wrapper.props().mode !== 'default' )
         {

--- a/src/DatePicker/tests.jsx
+++ b/src/DatePicker/tests.jsx
@@ -189,14 +189,14 @@ prevIsDisabled', () =>
     } );
 
 
-    describe( 'blurHour()', () =>
+    describe( 'blurHourInput()', () =>
     {
         test( 'should trigger onBlur callback once', () =>
         {
             const onBlur = jest.fn();
             wrapper.setProps( { onBlur } );
 
-            driver.blurHour();
+            driver.blurHourInput();
             expect( onBlur ).toBeCalledTimes( 1 );
         } );
 
@@ -209,7 +209,7 @@ prevIsDisabled', () =>
                     'There\'s no input because <mode> is not <default>';
                 wrapper.setProps( { mode: 'date' } );
 
-                expect( () => driver.blurHour() ).toThrow( expectedError );
+                expect( () => driver.blurHourInput() ).toThrow( expectedError );
             } );
 
             test( 'should not trigger onBlur callback prop if mode is not \
@@ -223,7 +223,7 @@ prevIsDisabled', () =>
 
                 try
                 {
-                    driver.blurHour();
+                    driver.blurHourInput();
                 }
                 catch ( error )
                 {
@@ -243,7 +243,7 @@ prevIsDisabled', () =>
                     isDisabled : true,
                 } );
 
-                expect( () => driver.blurHour() ).toThrow( expectedError );
+                expect( () => driver.blurHourInput() ).toThrow( expectedError );
             } );
 
             test( 'should not trigger onBlur callback prop when isDisabled', () =>
@@ -256,7 +256,7 @@ prevIsDisabled', () =>
 
                 try
                 {
-                    driver.blurHour();
+                    driver.blurHourInput();
                 }
                 catch ( error )
                 {
@@ -267,14 +267,14 @@ prevIsDisabled', () =>
     } );
 
 
-    describe( 'focusHour()', () =>
+    describe( 'focusHourInput()', () =>
     {
         test( 'should trigger onFocus callback once', () =>
         {
             const onFocus = jest.fn();
             wrapper.setProps( { onFocus } );
 
-            driver.focusHour();
+            driver.focusHourInput();
             expect( onFocus ).toBeCalledTimes( 1 );
         } );
 
@@ -287,7 +287,7 @@ prevIsDisabled', () =>
                     'There\'s no input because <mode> is not <default>';
                 wrapper.setProps( { mode: 'date' } );
 
-                expect( () => driver.focusHour() ).toThrow( expectedError );
+                expect( () => driver.focusHourInput() ).toThrow( expectedError );
             } );
 
             test( 'should not trigger onFocus callback prop if mode is not \
@@ -301,7 +301,7 @@ prevIsDisabled', () =>
 
                 try
                 {
-                    driver.focusHour();
+                    driver.focusHourInput();
                 }
                 catch ( error )
                 {
@@ -321,7 +321,7 @@ prevIsDisabled', () =>
                     isDisabled : true,
                 } );
 
-                expect( () => driver.focusHour() ).toThrow( expectedError );
+                expect( () => driver.focusHourInput() ).toThrow( expectedError );
             } );
 
             test( 'should not trigger onFocus callback prop when isDisabled', () =>
@@ -334,7 +334,7 @@ prevIsDisabled', () =>
 
                 try
                 {
-                    driver.focusHour();
+                    driver.focusHourInput();
                 }
                 catch ( error )
                 {
@@ -345,14 +345,14 @@ prevIsDisabled', () =>
     } );
 
 
-    describe( 'changeHour()', () =>
+    describe( 'changeHourInput()', () =>
     {
         test( 'should trigger onChange callback once', () =>
         {
             const onChange = jest.fn();
             wrapper.setProps( { onChange } );
 
-            driver.changeHour();
+            driver.changeHourInput();
             expect( onChange ).toBeCalledTimes( 1 );
         } );
 
@@ -364,7 +364,7 @@ prevIsDisabled', () =>
                     'There\'s no input because <mode> is not <default>';
                 wrapper.setProps( { mode: 'date' } );
 
-                expect( () => driver.changeHour() ).toThrow( expectedError );
+                expect( () => driver.changeHourInput() ).toThrow( expectedError );
             } );
 
             test( 'should not trigger onChange callback prop if mode is not \
@@ -378,7 +378,7 @@ prevIsDisabled', () =>
 
                 try
                 {
-                    driver.changeHour();
+                    driver.changeHourInput();
                 }
                 catch ( error )
                 {
@@ -398,7 +398,7 @@ prevIsDisabled', () =>
                     isDisabled : true,
                 } );
 
-                expect( () => driver.changeHour() ).toThrow( expectedError );
+                expect( () => driver.changeHourInput() ).toThrow( expectedError );
             } );
 
             test( 'should not trigger onChange callback prop when isDisabled', () =>
@@ -411,7 +411,7 @@ prevIsDisabled', () =>
 
                 try
                 {
-                    driver.changeHour();
+                    driver.changeHourInput();
                 }
                 catch ( error )
                 {
@@ -431,7 +431,7 @@ prevIsDisabled', () =>
                     isReadOnly : true,
                 } );
 
-                expect( () => driver.changeHour() ).toThrow( expectedError );
+                expect( () => driver.changeHourInput() ).toThrow( expectedError );
             } );
 
             test( 'should not trigger onChange callback prop when isReadOnly', () =>
@@ -444,7 +444,7 @@ prevIsDisabled', () =>
 
                 try
                 {
-                    driver.changeHour();
+                    driver.changeHourInput();
                 }
                 catch ( error )
                 {
@@ -455,14 +455,14 @@ prevIsDisabled', () =>
     } );
 
 
-    describe( 'keyPressHour()', () =>
+    describe( 'keyPressHourInput()', () =>
     {
         test( 'should trigger onKeyPress callback once', () =>
         {
             const onKeyPress = jest.fn();
             wrapper.setProps( { onKeyPress } );
 
-            driver.keyPressHour();
+            driver.keyPressHourInput();
             expect( onKeyPress ).toBeCalledTimes( 1 );
         } );
 
@@ -475,7 +475,7 @@ prevIsDisabled', () =>
                     'There\'s no input because <mode> is not <default>';
                 wrapper.setProps( { mode: 'date' } );
 
-                expect( () => driver.keyPressHour() ).toThrow( expectedError );
+                expect( () => driver.keyPressHourInput() ).toThrow( expectedError );
             } );
 
             test( 'should not trigger onKeyPress callback prop if mode is not \
@@ -489,7 +489,7 @@ prevIsDisabled', () =>
 
                 try
                 {
-                    driver.keyPressHour();
+                    driver.keyPressHourInput();
                 }
                 catch ( error )
                 {
@@ -509,7 +509,7 @@ prevIsDisabled', () =>
                     isDisabled : true,
                 } );
 
-                expect( () => driver.keyPressHour() ).toThrow( expectedError );
+                expect( () => driver.keyPressHourInput() ).toThrow( expectedError );
             } );
 
             test( 'should not trigger onKeyPress callback prop when isDisabled', () =>
@@ -522,7 +522,7 @@ prevIsDisabled', () =>
 
                 try
                 {
-                    driver.keyPressHour();
+                    driver.keyPressHourInput();
                 }
                 catch ( error )
                 {
@@ -533,14 +533,14 @@ prevIsDisabled', () =>
     } );
 
 
-    describe( 'blurMinute()', () =>
+    describe( 'blurMinuteInput()', () =>
     {
         test( 'should trigger onBlur callback once', () =>
         {
             const onBlur = jest.fn();
             wrapper.setProps( { onBlur } );
 
-            driver.blurMinute();
+            driver.blurMinuteInput();
             expect( onBlur ).toBeCalledTimes( 1 );
         } );
 
@@ -553,7 +553,7 @@ prevIsDisabled', () =>
                     'There\'s no input because <mode> is not <default>';
                 wrapper.setProps( { mode: 'month' } );
 
-                expect( () => driver.blurMinute() ).toThrow( expectedError );
+                expect( () => driver.blurMinuteInput() ).toThrow( expectedError );
             } );
 
             test( 'should not trigger onBlur callback prop if mode is not \
@@ -564,7 +564,7 @@ prevIsDisabled', () =>
 
                 try
                 {
-                    driver.blurMinute();
+                    driver.blurMinuteInput();
                 }
                 catch ( error )
                 {
@@ -584,7 +584,7 @@ prevIsDisabled', () =>
                     isDisabled : true,
                 } );
 
-                expect( () => driver.blurMinute() ).toThrow( expectedError );
+                expect( () => driver.blurMinuteInput() ).toThrow( expectedError );
             } );
 
             test( 'should not trigger onBlur callback prop when isDisabled', () =>
@@ -594,7 +594,7 @@ prevIsDisabled', () =>
 
                 try
                 {
-                    driver.blurMinute();
+                    driver.blurMinuteInput();
                 }
                 catch ( error )
                 {
@@ -605,14 +605,14 @@ prevIsDisabled', () =>
     } );
 
 
-    describe( 'focusMinute()', () =>
+    describe( 'focusMinuteInput()', () =>
     {
         test( 'should trigger onFocus callback once', () =>
         {
             const onFocus = jest.fn();
             wrapper.setProps( { onFocus } );
 
-            driver.focusMinute();
+            driver.focusMinuteInput();
             expect( onFocus ).toBeCalledTimes( 1 );
         } );
 
@@ -625,7 +625,7 @@ prevIsDisabled', () =>
                     'There\'s no input because <mode> is not <default>';
                 wrapper.setProps( { mode: 'month' } );
 
-                expect( () => driver.focusMinute() ).toThrow( expectedError );
+                expect( () => driver.focusMinuteInput() ).toThrow( expectedError );
             } );
 
             test( 'should not trigger onFocus callback prop when <mode> is not \
@@ -636,7 +636,7 @@ prevIsDisabled', () =>
 
                 try
                 {
-                    driver.focusMinute();
+                    driver.focusMinuteInput();
                 }
                 catch ( error )
                 {
@@ -656,7 +656,7 @@ prevIsDisabled', () =>
                     isDisabled : true,
                 } );
 
-                expect( () => driver.focusMinute() ).toThrow( expectedError );
+                expect( () => driver.focusMinuteInput() ).toThrow( expectedError );
             } );
 
             test( 'should not trigger onFocus callback prop when isDisabled', () =>
@@ -666,7 +666,7 @@ prevIsDisabled', () =>
 
                 try
                 {
-                    driver.focusMinute();
+                    driver.focusMinuteInput();
                 }
                 catch ( error )
                 {
@@ -677,14 +677,14 @@ prevIsDisabled', () =>
     } );
 
 
-    describe( 'changeMinute()', () =>
+    describe( 'changeMinuteInput()', () =>
     {
         test( 'should trigger onChange callback once', () =>
         {
             const onChange = jest.fn();
             wrapper.setProps( { onChange } );
 
-            driver.changeMinute();
+            driver.changeMinuteInput();
             expect( onChange ).toBeCalledTimes( 1 );
         } );
 
@@ -697,7 +697,7 @@ prevIsDisabled', () =>
                     'There\'s no input because <mode> is not <default>';
                 wrapper.setProps( { mode: 'date' } );
 
-                expect( () => driver.changeMinute() ).toThrow( expectedError );
+                expect( () => driver.changeMinuteInput() ).toThrow( expectedError );
             } );
 
             test( 'should not trigger onChange callback prop when <mode> is \
@@ -708,7 +708,7 @@ not <default>', () =>
 
                 try
                 {
-                    driver.changeMinute();
+                    driver.changeMinuteInput();
                 }
                 catch ( error )
                 {
@@ -728,7 +728,7 @@ not <default>', () =>
                     isDisabled : true,
                 } );
 
-                expect( () => driver.changeMinute() ).toThrow( expectedError );
+                expect( () => driver.changeMinuteInput() ).toThrow( expectedError );
             } );
 
             test( 'should not trigger onChange callback prop when isDisabled', () =>
@@ -741,7 +741,7 @@ not <default>', () =>
 
                 try
                 {
-                    driver.changeMinute();
+                    driver.changeMinuteInput();
                 }
                 catch ( error )
                 {
@@ -761,7 +761,7 @@ not <default>', () =>
                     isReadOnly : true,
                 } );
 
-                expect( () => driver.changeMinute() ).toThrow( expectedError );
+                expect( () => driver.changeMinuteInput() ).toThrow( expectedError );
             } );
 
             test( 'should not trigger onChange callback prop when isReadOnly', () =>
@@ -774,7 +774,7 @@ not <default>', () =>
 
                 try
                 {
-                    driver.changeMinute();
+                    driver.changeMinuteInput();
                 }
                 catch ( error )
                 {
@@ -785,14 +785,14 @@ not <default>', () =>
     } );
 
 
-    describe( 'keyPressMinute()', () =>
+    describe( 'keyPressMinuteInput()', () =>
     {
         test( 'should trigger onKeyPress callback once', () =>
         {
             const onKeyPress = jest.fn();
             wrapper.setProps( { onKeyPress } );
 
-            driver.keyPressMinute();
+            driver.keyPressMinuteInput();
             expect( onKeyPress ).toBeCalledTimes( 1 );
         } );
 
@@ -805,7 +805,7 @@ not <default>', () =>
                     'There\'s no input because <mode> is not <default>';
                 wrapper.setProps( { mode: 'date' } );
 
-                expect( () => driver.keyPressMinute() ).toThrow( expectedError );
+                expect( () => driver.keyPressMinuteInput() ).toThrow( expectedError );
             } );
 
             test( 'should not trigger onKeyPress callback prop when <mode> is \
@@ -816,7 +816,7 @@ not <default>', () =>
 
                 try
                 {
-                    driver.keyPressMinute();
+                    driver.keyPressMinuteInput();
                 }
                 catch ( error )
                 {
@@ -836,7 +836,7 @@ not <default>', () =>
                     isDisabled : true,
                 } );
 
-                expect( () => driver.keyPressMinute() ).toThrow( expectedError );
+                expect( () => driver.keyPressMinuteInput() ).toThrow( expectedError );
             } );
 
             test( 'should not trigger onKeyPress callback prop when isDisabled', () =>
@@ -849,7 +849,7 @@ not <default>', () =>
 
                 try
                 {
-                    driver.keyPressMinute();
+                    driver.keyPressMinuteInput();
                 }
                 catch ( error )
                 {

--- a/src/DateTimeInput/driver.js
+++ b/src/DateTimeInput/driver.js
@@ -10,21 +10,24 @@
 import { DatePicker, IconButton } from 'nessie-ui';
 
 
+const ERR = {
+    INPUT_ERR : ( event, state ) =>
+        `Main input cannot simulate ${event} since it is ${state}`,
+};
+
 export default class DateTimeInputDriver
 {
     constructor( wrapper )
     {
-        this.wrapper     = wrapper;
-        this.cssMap      = wrapper.children().props().cssMap;
+        this.wrapper    = wrapper;
+        this.cssMap     = wrapper.children().props().cssMap;
 
-        this.mainInput   = wrapper.find( `.${this.cssMap.input}` );
-        this.hourInput   = wrapper.find( `.${this.cssMap.hour}` );
-        this.minuteInput = wrapper.find( `.${this.cssMap.min}` );
-        this.calendar    = wrapper.find( DatePicker );
-        this.icon        = wrapper.find( IconButton )
+        this.mainInput  = wrapper.find( `.${this.cssMap.input}` );
+        this.calendar   = wrapper.find( DatePicker );
+        this.icon       = wrapper.find( IconButton )
             .findWhere( node => node.props().iconType === 'calendar' );
-        this.prev        = wrapper.find( `.${this.cssMap.prev}` );
-        this.next        = wrapper.find( `.${this.cssMap.next}` );
+        this.prev       = wrapper.find( `.${this.cssMap.prev}` );
+        this.next       = wrapper.find( `.${this.cssMap.next}` );
     }
 
     blurMainInput()
@@ -41,25 +44,25 @@ export default class DateTimeInputDriver
 
     blurHourInput()
     {
-        this.hourInput.simulate( 'blur' );
+        this.calendar.driver().blurHourInput();
         return this;
     }
 
     focusHourInput()
     {
-        this.hourInput.simulate( 'focus' );
+        this.calendar.driver().focusHourInput();
         return this;
     }
 
     blurMinuteInput()
     {
-        this.minuteInput.simulate( 'blur' );
+        this.calendar.driver().blurMinuteInput();
         return this;
     }
 
     focusMinuteInput()
     {
-        this.minuteInput.simulate( 'focus' );
+        this.calendar.driver().focusMinuteInput();
         return this;
     }
 
@@ -96,21 +99,53 @@ export default class DateTimeInputDriver
         return this;
     }
 
-    keyPressInput( keyCode )
+    changeMainInput( val )
     {
-        this.wrapper.driver().keyPressInput( keyCode );
+        if ( this.wrapper.props().isDisabled )
+        {
+            throw new Error( ERR.TIMEINPUT_ERR( 'change', 'disabled' ) );
+        }
+
+        if ( this.wrapper.props().isReadOnly ||
+            this.wrapper.props().isReadOnlyInput )
+        {
+            throw new Error( ERR.TIMEINPUT_ERR( 'change', 'read only' ) );
+        }
+
+        const node = this.mainInput.getNode();
+        node.value = val;
+
+        this.mainInput.simulate( 'change' );
+        return this;
+    }
+
+    keyDownMainInput( keyCode )
+    {
+        this.mainInput.simulate( 'keyDown', { keyCode, which: keyCode } );
+        return this;
+    }
+
+    keyUpMainInput( keyCode )
+    {
+        this.mainInput.simulate( 'keyUp', { keyCode, which: keyCode } );
+        return this;
+    }
+
+    keyPressMainInput( keyCode )
+    {
+        this.mainInput.simulate( 'keyPress', { keyCode, which: keyCode } );
         return this;
     }
 
     keyPressHour( keyCode )
     {
-        this.calendar.driver().keyPressHour( keyCode );
+        this.calendar.driver().keyPressHourInput( keyCode );
         return this;
     }
 
     keyPressMinute( keyCode )
     {
-        this.calendar.driver().keyPressMinute( keyCode );
+        this.calendar.driver().keyPressMinuteInput( keyCode );
         return this;
     }
 

--- a/src/DateTimeInput/driver.js
+++ b/src/DateTimeInput/driver.js
@@ -32,12 +32,22 @@ export default class DateTimeInputDriver
 
     blurMainInput()
     {
+        if ( this.wrapper.props().isDisabled )
+        {
+            throw new Error( ERR.INPUT_ERR( 'blur', 'disabled' ) );
+        }
+
         this.mainInput.simulate( 'blur' );
         return this;
     }
 
     focusMainInput()
     {
+        if ( this.wrapper.props().isDisabled )
+        {
+            throw new Error( ERR.INPUT_ERR( 'focus', 'disabled' ) );
+        }
+
         this.mainInput.simulate( 'focus' );
         return this;
     }
@@ -103,13 +113,13 @@ export default class DateTimeInputDriver
     {
         if ( this.wrapper.props().isDisabled )
         {
-            throw new Error( ERR.TIMEINPUT_ERR( 'change', 'disabled' ) );
+            throw new Error( ERR.INPUT_ERR( 'change', 'disabled' ) );
         }
 
         if ( this.wrapper.props().isReadOnly ||
             this.wrapper.props().isReadOnlyInput )
         {
-            throw new Error( ERR.TIMEINPUT_ERR( 'change', 'read only' ) );
+            throw new Error( ERR.INPUT_ERR( 'change', 'read only' ) );
         }
 
         const node = this.mainInput.getNode();
@@ -119,31 +129,58 @@ export default class DateTimeInputDriver
         return this;
     }
 
+    changeHourInput( val )
+    {
+        this.calendar.driver().changeHourInput( val );
+        return this;
+    }
+
+    changeMinuteInput( val )
+    {
+        this.calendar.driver().changeMinuteInput( val );
+        return this;
+    }
+
     keyDownMainInput( keyCode )
     {
+        if ( this.wrapper.props().isDisabled )
+        {
+            throw new Error( ERR.INPUT_ERR( 'keyDown', 'disabled' ) );
+        }
+
         this.mainInput.simulate( 'keyDown', { keyCode, which: keyCode } );
         return this;
     }
 
     keyUpMainInput( keyCode )
     {
+        if ( this.wrapper.props().isDisabled )
+        {
+            throw new Error( ERR.INPUT_ERR( 'keyUp', 'disabled' ) );
+        }
+
         this.mainInput.simulate( 'keyUp', { keyCode, which: keyCode } );
         return this;
     }
 
     keyPressMainInput( keyCode )
     {
+        if ( this.wrapper.props().isDisabled )
+        {
+            throw new Error( ERR.INPUT_ERR( 'keyPress', 'disabled' ) );
+        }
+
         this.mainInput.simulate( 'keyPress', { keyCode, which: keyCode } );
         return this;
     }
 
-    keyPressHour( keyCode )
+    keyPressHourInput( keyCode )
     {
         this.calendar.driver().keyPressHourInput( keyCode );
         return this;
     }
 
-    keyPressMinute( keyCode )
+    keyPressMinuteInput( keyCode )
     {
         this.calendar.driver().keyPressMinuteInput( keyCode );
         return this;

--- a/src/DateTimeInput/tests.jsx
+++ b/src/DateTimeInput/tests.jsx
@@ -37,6 +37,41 @@ describe( 'DateTimeInputDriver', () =>
             driver.blurMainInput();
             expect( onBlur ).toBeCalledTimes( 1 );
         } );
+
+        describe( 'isDisabled', () =>
+        {
+            test( 'should throw the expected error when isDisabled', () =>
+            {
+                const expectedError =
+                    'Main input cannot simulate blur since it is disabled';
+                wrapper.setProps( {
+                    isDisabled : true,
+                } );
+
+                expect( () => driver.blurMainInput() ).toThrow( expectedError );
+            } );
+
+            test(
+                'should not trigger onBlur callback prop when isDisabled',
+                () =>
+                {
+                    const onBlur = jest.fn();
+                    wrapper.setProps( {
+                        onBlur,
+                        isDisabled : true,
+                    } );
+
+                    try
+                    {
+                        driver.blurMainInput();
+                    }
+                    catch ( error )
+                    {
+                        expect( onBlur ).not.toBeCalled();
+                    }
+                },
+            );
+        } );
     } );
 
     describe( 'focusMainInput()', () =>
@@ -48,6 +83,42 @@ describe( 'DateTimeInputDriver', () =>
 
             driver.focusMainInput();
             expect( onFocus ).toBeCalledTimes( 1 );
+        } );
+
+        describe( 'isDisabled', () =>
+        {
+            test( 'should throw the expected error when isDisabled', () =>
+            {
+                const expectedError =
+                    'Main input cannot simulate focus since it is disabled';
+                wrapper.setProps( {
+                    isDisabled : true,
+                } );
+
+                expect( () => driver.focusMainInput() )
+                    .toThrow( expectedError );
+            } );
+
+            test(
+                'should not trigger onFocus callback prop when isDisabled',
+                () =>
+                {
+                    const onFocus = jest.fn();
+                    wrapper.setProps( {
+                        onFocus,
+                        isDisabled : true,
+                    } );
+
+                    try
+                    {
+                        driver.focusMainInput();
+                    }
+                    catch ( error )
+                    {
+                        expect( onFocus ).not.toBeCalled();
+                    }
+                },
+            );
         } );
     } );
 
@@ -200,27 +271,289 @@ describe( 'DateTimeInputDriver', () =>
     } );
 
 
-    describe( 'keyPressHour()', () =>
+    describe( 'changeMainInput( val )', () =>
+    {
+        test( 'should trigger onChange callback prop once', () =>
+        {
+            const onChange = jest.fn();
+            wrapper.setProps( {
+                onChange,
+            } );
+
+            driver.changeMainInput();
+            expect( onChange ).toBeCalledTimes( 1 );
+        } );
+
+
+        describe( 'isDisabled', () =>
+        {
+            test( 'should throw the expected error when isDisabled', () =>
+            {
+                const expectedError =
+                    'Main input cannot simulate change since it is disabled';
+                wrapper.setProps( {
+                    isDisabled : true,
+                } );
+
+                expect( () => driver.changeMainInput() )
+                    .toThrow( expectedError );
+            } );
+
+            test(
+                'should not trigger onChange callback prop when isDisabled',
+                () =>
+                {
+                    const onChange = jest.fn();
+                    wrapper.setProps( {
+                        onChange,
+                        isDisabled : true,
+                    } );
+
+                    try
+                    {
+                        driver.changeMainInput();
+                    }
+                    catch ( error )
+                    {
+                        expect( onChange ).not.toBeCalled();
+                    }
+                },
+            );
+        } );
+
+
+        describe( 'isReadOnly', () =>
+        {
+            test( 'should throw the expected error when isReadOnly', () =>
+            {
+                const expectedError =
+                    'Main input cannot simulate change since it is read only';
+                wrapper.setProps( {
+                    isReadOnly : true,
+                } );
+
+                expect( () => driver.changeMainInput() )
+                    .toThrow( expectedError );
+            } );
+
+            test(
+                'should not trigger onChange callback prop when isReadOnly',
+                () =>
+                {
+                    const onChange = jest.fn();
+                    wrapper.setProps( {
+                        onChange,
+                        isReadOnlyInput : true,
+                    } );
+
+                    try
+                    {
+                        driver.changeMainInput();
+                    }
+                    catch ( error )
+                    {
+                        expect( onChange ).not.toBeCalled();
+                    }
+                },
+            );
+        } );
+    } );
+
+
+    describe( 'changeHourInput()', () =>
+    {
+        test( 'should trigger onChange callback once', () =>
+        {
+            const onChange = jest.fn();
+            wrapper.setProps( { onChange } );
+
+            driver.changeHourInput();
+            expect( onChange ).toBeCalledTimes( 1 );
+        } );
+    } );
+
+
+    describe( 'changeMinuteInput()', () =>
+    {
+        test( 'should trigger onChange callback once', () =>
+        {
+            const onChange = jest.fn();
+            wrapper.setProps( { onChange } );
+
+            driver.changeMinuteInput();
+            expect( onChange ).toBeCalledTimes( 1 );
+        } );
+    } );
+
+
+    describe( 'keyDownMainInput( keyCode )', () =>
+    {
+        test( 'should call onKeyDown once', () =>
+        {
+            const onKeyDown = jest.fn();
+            wrapper.setProps( { onKeyDown } );
+
+            driver.keyDownMainInput();
+            expect( onKeyDown ).toBeCalledTimes( 1 );
+        } );
+
+        describe( 'isDisabled', () =>
+        {
+            test( 'should throw the expected error when isDisabled', () =>
+            {
+                const expectedError =
+                    'Main input cannot simulate keyDown since it is disabled';
+                wrapper.setProps( {
+                    isDisabled : true,
+                } );
+
+                expect( () => driver.keyDownMainInput() )
+                    .toThrow( expectedError );
+            } );
+
+            test(
+                'should not trigger onKeyDown callback prop when isDisabled',
+                () =>
+                {
+                    const onKeyDown = jest.fn();
+                    wrapper.setProps( {
+                        onKeyDown,
+                        isDisabled : true,
+                    } );
+
+                    try
+                    {
+                        driver.keyDownMainInput();
+                    }
+                    catch ( error )
+                    {
+                        expect( onKeyDown ).not.toBeCalled();
+                    }
+                },
+            );
+        } );
+    } );
+
+
+    describe( 'keyUpMainInput( keyCode )', () =>
+    {
+        test( 'should call onKeyUp once', () =>
+        {
+            const onKeyUp = jest.fn();
+            wrapper.setProps( { onKeyUp } );
+
+            driver.keyUpMainInput();
+            expect( onKeyUp ).toBeCalledTimes( 1 );
+        } );
+
+        describe( 'isDisabled', () =>
+        {
+            test( 'should throw the expected error when isDisabled', () =>
+            {
+                const expectedError =
+                    'Main input cannot simulate keyUp since it is disabled';
+                wrapper.setProps( {
+                    isDisabled : true,
+                } );
+
+                expect( () => driver.keyUpMainInput() )
+                    .toThrow( expectedError );
+            } );
+
+            test(
+                'should not trigger onKeyUp callback prop when isDisabled',
+                () =>
+                {
+                    const onKeyUp = jest.fn();
+                    wrapper.setProps( {
+                        onKeyUp,
+                        isDisabled : true,
+                    } );
+
+                    try
+                    {
+                        driver.keyUpMainInput();
+                    }
+                    catch ( error )
+                    {
+                        expect( onKeyUp ).not.toBeCalled();
+                    }
+                },
+            );
+        } );
+    } );
+
+
+    describe( 'keyPressMainInput( keyCode )', () =>
+    {
+        test( 'should call onKeyPress once', () =>
+        {
+            const onKeyPress = jest.fn();
+            wrapper.setProps( { onKeyPress } );
+
+            driver.keyPressMainInput();
+            expect( onKeyPress ).toBeCalledTimes( 1 );
+        } );
+
+        describe( 'isDisabled', () =>
+        {
+            test( 'should throw the expected error when isDisabled', () =>
+            {
+                const expectedError =
+                    'Main input cannot simulate keyPress since it is disabled';
+                wrapper.setProps( {
+                    isDisabled : true,
+                } );
+
+                expect( () => driver.keyPressMainInput() )
+                    .toThrow( expectedError );
+            } );
+
+            test(
+                'should not trigger onKeyPress callback prop when isDisabled',
+                () =>
+                {
+                    const onKeyPress = jest.fn();
+                    wrapper.setProps( {
+                        onKeyPress,
+                        isDisabled : true,
+                    } );
+
+                    try
+                    {
+                        driver.keyPressMainInput();
+                    }
+                    catch ( error )
+                    {
+                        expect( onKeyPress ).not.toBeCalled();
+                    }
+                },
+            );
+        } );
+    } );
+
+
+    describe( 'keyPressHourInput()', () =>
     {
         test( 'should trigger onKeyPress callback once', () =>
         {
             const onKeyPress = jest.fn();
             wrapper.setProps( { onKeyPress } );
 
-            driver.keyPressHour();
+            driver.keyPressHourInput();
             expect( onKeyPress ).toBeCalledTimes( 1 );
         } );
     } );
 
 
-    describe( 'keyPressMinute()', () =>
+    describe( 'keyPressMinuteInput()', () =>
     {
         test( 'should trigger onKeyPress callback once', () =>
         {
             const onKeyPress = jest.fn();
             wrapper.setProps( { onKeyPress } );
 
-            driver.keyPressMinute();
+            driver.keyPressMinuteInput();
             expect( onKeyPress ).toBeCalledTimes( 1 );
         } );
     } );


### PR DESCRIPTION
For #717:

- added `onChange` driver and tests
- updated/renamed current methods for `hour` and `minute` inputs