### PR TITLE
Remove test globals

### DIFF
--- a/src/Animate/tests.jsx
+++ b/src/Animate/tests.jsx
@@ -7,14 +7,12 @@
  *
  */
 
-/* eslint-disable no-magic-numbers, no-multi-str, no-unused-expressions */
-/* global test */
-
+/* eslint-disable no-magic-numbers */
 
 import React        from 'react';
 import { mount }    from 'enzyme';
 
-import Animate      from './index';
+import { Animate }  from '../index';
 
 describe( 'Animate', () =>
 {

--- a/src/Button/tests.jsx
+++ b/src/Button/tests.jsx
@@ -7,16 +7,12 @@
  *
  */
 
-/* eslint-disable no-magic-numbers, no-multi-str, no-unused-expressions */
-/* global jest test */
+/* eslint-disable no-magic-numbers */
 
-import React              from 'react';
-import { mount, shallow } from 'enzyme';
+import React                        from 'react';
+import { mount, shallow }           from 'enzyme';
 
-import Icon               from '../Icon';
-import Spinner            from '../Spinner';
-
-import Button             from './index';
+import { Button, Icon, Spinner }    from '../index';
 
 
 describe( 'Button', () =>

--- a/src/Card/tests.jsx
+++ b/src/Card/tests.jsx
@@ -7,13 +7,12 @@
  *
  */
 
-/* global test */
-/* eslint-disable no-magic-numbers, no-multi-str */
+/* eslint-disable no-magic-numbers */
 
 import React        from 'react';
 import { mount }    from 'enzyme';
 
-import Card         from './index';
+import { Card }     from '../index';
 
 describe( 'Card', () =>
 {

--- a/src/CheckableGroup/tests.jsx
+++ b/src/CheckableGroup/tests.jsx
@@ -7,15 +7,12 @@
  *
  */
 
-/* eslint-disable no-magic-numbers, no-multi-str, no-unused-expressions */
-/* global jest test */
+/* eslint-disable no-magic-numbers */
 
-import React            from 'react';
-import { mount }        from 'enzyme';
+import React                        from 'react';
+import { mount }                    from 'enzyme';
 
-import { Checkbox }     from '../index';
-
-import CheckableGroup   from './index';
+import { Checkbox, CheckableGroup } from '../index';
 
 describe( 'CheckableGroupDriver', () =>
 {
@@ -52,10 +49,9 @@ describe( 'CheckableGroupDriver', () =>
         {
             test( 'throws the expected error when isDisabled', () =>
             {
-                wrapper.setProps( { isDisabled: true, label: 'Tekeli-li' } );
-
                 const expectedError = 'CheckableGroup cannot simulate change \
 since it is disabled';
+                wrapper.setProps( { isDisabled: true, label: 'Tekeli-li' } );
 
                 expect( () => driver.change() ).toThrow( expectedError );
             } );
@@ -85,10 +81,9 @@ since it is disabled';
         {
             test( 'throws the expected error when isReadOnly', () =>
             {
-                wrapper.setProps( { isReadOnly: true, label: 'Tekeli-li' } );
-
                 const expectedError = 'CheckableGroup cannot simulate change \
 since it is read only';
+                wrapper.setProps( { isReadOnly: true, label: 'Tekeli-li' } );
 
                 expect( () => driver.change() ).toThrow( expectedError );
             } );
@@ -123,7 +118,6 @@ since it is read only';
             wrapper.setProps( { onMouseOver } );
 
             driver.mouseOver();
-
             expect( onMouseOver ).toBeCalledTimes( 1 );
         } );
     } );
@@ -137,7 +131,6 @@ since it is read only';
             wrapper.setProps( { onMouseOut } );
 
             driver.mouseOut();
-
             expect( onMouseOut ).toBeCalledTimes( 1 );
         } );
     } );

--- a/src/Checkbox/tests.jsx
+++ b/src/Checkbox/tests.jsx
@@ -7,15 +7,13 @@
  *
  */
 
-/* eslint-disable no-magic-numbers, no-multi-str, no-unused-expressions */
-/* global jest test */
+/* eslint-disable no-magic-numbers */
 
 import React              from 'react';
 import { shallow, mount } from 'enzyme';
 
 import Checkable          from '../proto/Checkable';
-
-import Checkbox           from './index';
+import { Checkbox }       from '../index';
 
 describe( 'Checkbox', () =>
 {

--- a/src/CodeEditor/tests.jsx
+++ b/src/CodeEditor/tests.jsx
@@ -7,9 +7,7 @@
  *
  */
 
-/* eslint-disable no-magic-numbers, no-multi-str, no-unused-expressions */
-/* global jest test */
-/* eslint no-console: 0*/
+/* eslint-disable no-magic-numbers */
 
 import React              from 'react';
 import { shallow, mount } from 'enzyme';
@@ -48,14 +46,12 @@ describe( 'CodeEditor', () =>
 describe( 'CodeEditorDriver', () =>
 {
     let wrapper;
-    let CodeMirror;
     let driver;
 
     beforeEach( () =>
     {
-        wrapper    = mount( <CodeEditor /> );
-        CodeMirror = wrapper.instance().codeMirror;
-        driver     = wrapper.driver();
+        wrapper = mount( <CodeEditor /> );
+        driver  = wrapper.driver();
     } );
 
 
@@ -145,7 +141,6 @@ it is read only';
             wrapper.setProps( { onFocus } );
 
             driver.focus();
-
             expect( onFocus ).toBeCalledTimes( 1 );
         } );
 

--- a/src/Column/tests.jsx
+++ b/src/Column/tests.jsx
@@ -7,14 +7,12 @@
  *
  */
 
-/* global test */
-/* eslint no-console: 0*/
-/* eslint-disable no-magic-numbers, no-multi-str, no-unused-expressions */
+/* eslint-disable no-magic-numbers */
 
 import React        from 'react';
 import { mount }    from 'enzyme';
 
-import Column       from './index';
+import { Column }   from '../index';
 
 describe( 'Column', () =>
 {

--- a/src/ComboBox/tests.jsx
+++ b/src/ComboBox/tests.jsx
@@ -7,7 +7,7 @@
  *
  */
 
-/* global test jest */
+/* eslint-disable no-magic-numbers */
 
 import React        from 'react';
 import { mount }    from 'enzyme';
@@ -56,8 +56,8 @@ describe( 'ComboBoxDriver', () =>
 
     beforeEach( () =>
     {
-        wrapper  = mount( <ComboBox /> );
-        driver   = wrapper.driver();
+        wrapper = mount( <ComboBox /> );
+        driver  = wrapper.driver();
     } );
 
     describe( 'blur()', () =>
@@ -147,7 +147,6 @@ describe( 'ComboBoxDriver', () =>
             } );
 
             driver.clickOption();
-
             expect( onClickOption ).toBeCalledTimes( 1 );
         } );
     } );

--- a/src/DatePicker/tests.jsx
+++ b/src/DatePicker/tests.jsx
@@ -7,13 +7,12 @@
  *
  */
 
-/* global jest test */
-/* eslint-disable no-magic-numbers, no-multi-str, no-unused-expressions, max-len */
+/* eslint-disable no-magic-numbers, max-len */
 
 import React                from 'react';
 import { mount, shallow }   from 'enzyme';
 
-import DatePicker           from './index';
+import { DatePicker }       from '../index';
 
 describe( 'DatePicker', () =>
 {

--- a/src/DateTimeInput/tests.jsx
+++ b/src/DateTimeInput/tests.jsx
@@ -7,13 +7,12 @@
  *
  */
 
-/* global jest test */
 /* eslint-disable no-magic-numbers */
 
-import React                    from 'react';
-import { mount }                from 'enzyme';
+import React                from 'react';
+import { mount }            from 'enzyme';
 
-import { DateTimeInput }        from '../index';
+import { DateTimeInput }    from '../index';
 
 describe( 'DateTimeInputDriver', () =>
 {

--- a/src/DimensionsInput/tests.jsx
+++ b/src/DimensionsInput/tests.jsx
@@ -7,17 +7,12 @@
  *
  */
 
-/* global test */
 /* eslint-disable no-magic-numbers */
 
+import React                                 from 'react';
+import { shallow }                           from 'enzyme';
 
-import React                from 'react';
-import { shallow }          from 'enzyme';
-
-import { InputField, Text } from '../index';
-
-import DimensionsInput      from './index';
-
+import { DimensionsInput, InputField, Text } from '../index';
 
 describe( 'DimensionsInput', () =>
 {

--- a/src/Divider/tests.jsx
+++ b/src/Divider/tests.jsx
@@ -8,14 +8,11 @@
  */
 
 /* eslint-disable no-magic-numbers */
-/* global test */
-/* eslint no-console: 0*/
-
 
 import React        from 'react';
 import { mount }    from 'enzyme';
 
-import Divider      from './index';
+import { Divider }  from '../index';
 
 describe( 'Divider', () =>
 {

--- a/src/DragNDrop/tests.jsx
+++ b/src/DragNDrop/tests.jsx
@@ -7,15 +7,12 @@
  *
  */
 
-/* eslint-disable no-magic-numbers, no-multi-str, no-unused-expressions */
-/* global test */
+/* eslint-disable no-magic-numbers */
 
-import React            from 'react';
-import { mount }        from 'enzyme';
+import React                from 'react';
+import { mount }            from 'enzyme';
 
-import { Text }         from '../index';
-
-import DragNDrop        from './index';
+import { DragNDrop, Text }  from '../index';
 
 describe( 'DragNDrop', () =>
 {

--- a/src/Dropdown/tests.jsx
+++ b/src/Dropdown/tests.jsx
@@ -7,13 +7,12 @@
  *
  */
 
-/* global test */
-/* eslint-disable no-magic-numbers, no-multi-str, no-unused-expressions */
+/* eslint-disable no-magic-numbers */
 
 import React        from 'react';
 import { mount }    from 'enzyme';
 
-import Dropdown     from './index';
+import { Dropdown } from '../index';
 
 describe( 'Dropdown', () =>
 {

--- a/src/Fieldset/tests.jsx
+++ b/src/Fieldset/tests.jsx
@@ -7,8 +7,7 @@
  *
  */
 
-/* global test */
-/* eslint-disable no-magic-numbers, no-multi-str, no-unused-expressions */
+/* eslint-disable no-magic-numbers */
 
 import React                from 'react';
 import { shallow, mount }   from 'enzyme';

--- a/src/FlounderDropdown/tests.jsx
+++ b/src/FlounderDropdown/tests.jsx
@@ -7,7 +7,7 @@
  *
  */
 
-/* global test jest */
+/* eslint-disable no-magic-numbers */
 
 import React              from 'react';
 import { mount, shallow } from 'enzyme';

--- a/src/Form/tests.jsx
+++ b/src/Form/tests.jsx
@@ -13,7 +13,7 @@
 import React              from 'react';
 import { mount, shallow } from 'enzyme';
 
-import Form               from './index';
+import { Form }           from '../index';
 
 describe( 'Form', () =>
 {
@@ -62,10 +62,9 @@ describe( 'FormDriver', () =>
         test( 'should fire the onSubmit callback prop once', () =>
         {
             const onSubmit = jest.fn();
-
             wrapper.setProps( { onSubmit } );
-            wrapper.driver().submit();
 
+            wrapper.driver().submit();
             expect( onSubmit ).toBeCalledTimes( 1 );
         } );
     } );

--- a/src/Form/tests.jsx
+++ b/src/Form/tests.jsx
@@ -7,8 +7,7 @@
  *
  */
 
-/* eslint-disable no-magic-numbers, no-multi-str, no-unused-expressions */
-/* global test jest */
+/* eslint-disable no-magic-numbers */
 
 import React              from 'react';
 import { mount, shallow } from 'enzyme';

--- a/src/Grid/tests.jsx
+++ b/src/Grid/tests.jsx
@@ -7,16 +7,12 @@
  *
  */
 
-/* eslint no-console: 0*/
-/* eslint-disable no-magic-numbers, no-multi-str */
+/* eslint-disable no-magic-numbers */
 
-import React      from 'react';
-import { mount }  from 'enzyme';
+import React            from 'react';
+import { mount }        from 'enzyme';
 
-import { Column } from '../index';
-
-import Grid       from './index';
-
+import { Column, Grid } from '../index';
 
 describe( 'Grid', () =>
 {
@@ -32,9 +28,7 @@ describe( 'Grid', () =>
         test( 'should return the content of the Grid or Column', () =>
         {
             wrapper.setProps( { children: <Column>Lightning Strike</Column> } );
-
-            const content = wrapper.children().first();
-            expect( content.text() ).toBe( 'Lightning Strike' );
+            expect( wrapper.text() ).toBe( 'Lightning Strike' );
         } );
     } );
 

--- a/src/H1/tests.jsx
+++ b/src/H1/tests.jsx
@@ -7,14 +7,12 @@
  *
  */
 
-/* global test */
-/* eslint-disable no-magic-numbers, no-multi-str, no-unused-expressions */
-
+/* eslint-disable no-magic-numbers */
 
 import React        from 'react';
 import { mount }    from 'enzyme';
 
-import H1           from './index';
+import { H1 }       from '../index';
 
 describe( 'H1', () =>
 {

--- a/src/H2/tests.jsx
+++ b/src/H2/tests.jsx
@@ -7,14 +7,12 @@
  *
  */
 
-/* global test */
-/* eslint-disable no-magic-numbers, no-multi-str, no-unused-expressions */
-
+/* eslint-disable no-magic-numbers */
 
 import React        from 'react';
 import { mount }    from 'enzyme';
 
-import H2           from './index';
+import { H2 }       from '../index';
 
 describe( 'H2', () =>
 {

--- a/src/H3/tests.jsx
+++ b/src/H3/tests.jsx
@@ -7,14 +7,12 @@
  *
  */
 
-/* global test */
-/* eslint-disable no-magic-numbers, no-multi-str, no-unused-expressions */
-
+/* eslint-disable no-magic-numbers */
 
 import React        from 'react';
 import { mount }    from 'enzyme';
 
-import H3           from './index';
+import { H3 }       from '../index';
 
 describe( 'H3', () =>
 {

--- a/src/H4/tests.jsx
+++ b/src/H4/tests.jsx
@@ -7,14 +7,12 @@
  *
  */
 
-/* global test */
-/* eslint-disable no-magic-numbers, no-multi-str, no-unused-expressions */
-
+/* eslint-disable no-magic-numbers */
 
 import React        from 'react';
 import { mount }    from 'enzyme';
 
-import H4           from './index';
+import { H4 }       from '../index';
 
 describe( 'H4', () =>
 {

--- a/src/Icon/tests.jsx
+++ b/src/Icon/tests.jsx
@@ -7,14 +7,12 @@
  *
  */
 
-/* global test jest */
-/* eslint-disable no-magic-numbers, no-multi-str, no-unused-expressions */
+/* eslint-disable no-magic-numbers */
 
 import React              from 'react';
 import { mount, shallow } from 'enzyme';
 
-import Icon               from './index';
-
+import { Icon }           from '../index';
 
 describe( 'Icon', () =>
 {

--- a/src/IconButton/tests.jsx
+++ b/src/IconButton/tests.jsx
@@ -7,16 +7,12 @@
  *
  */
 
-/* global test jest */
+/* eslint-disable no-magic-numbers */
 
+import React                from 'react';
+import { shallow, mount }   from 'enzyme';
 
-import React              from 'react';
-import { shallow, mount } from 'enzyme';
-
-import { Icon }           from '../index';
-
-import IconButton         from './index';
-
+import { Icon, IconButton } from '../index';
 
 describe( 'IconButton', () =>
 {

--- a/src/IconWithTooltip/tests.jsx
+++ b/src/IconWithTooltip/tests.jsx
@@ -7,16 +7,12 @@
  *
  */
 
-/* global test jest */
-/* eslint-disable no-magic-numbers, no-unused-expressions */
+/* eslint-disable no-magic-numbers */
 
-import React                from 'react';
-import { mount, shallow }   from 'enzyme';
+import React                        from 'react';
+import { mount, shallow }           from 'enzyme';
 
-import { Tooltip }          from '../index';
-
-import IconWithTooltip      from './index';
-
+import { IconWithTooltip, Tooltip } from '../index';
 
 describe( 'IconWithTooltip', () =>
 {

--- a/src/InputField/tests.jsx
+++ b/src/InputField/tests.jsx
@@ -7,8 +7,7 @@
  *
  */
 
-/* global test */
-/* eslint-disable no-magic-numbers, no-multi-str, no-unused-expressions */
+/* eslint-disable no-magic-numbers */
 
 import React          from 'react';
 import { mount }      from 'enzyme';

--- a/src/Label/tests.jsx
+++ b/src/Label/tests.jsx
@@ -7,13 +7,12 @@
  *
  */
 
-/* global test */
 /* eslint-disable no-magic-numbers*/
 
 import React        from 'react';
 import { mount }    from 'enzyme';
 
-import Label        from './index';
+import { Label }    from '../index';
 
 describe( 'Label', () =>
 {
@@ -59,11 +58,9 @@ describe( 'LabelDriver', () =>
         test( 'should call onMouseOver callback once', () =>
         {
             const onMouseOver = jest.fn();
-
             wrapper.setProps( { ...props, onMouseOver } );
 
             driver.mouseOver();
-
             expect( onMouseOver ).toBeCalledTimes( 1 );
         } );
     } );
@@ -74,11 +71,9 @@ describe( 'LabelDriver', () =>
         test( 'should call onMouseOver callback once', () =>
         {
             const onMouseOut = jest.fn();
-
             wrapper.setProps( { ...props, onMouseOut } );
 
             driver.mouseOut();
-
             expect( onMouseOut ).toBeCalledTimes( 1 );
         } );
     } );

--- a/src/ListBox/tests.jsx
+++ b/src/ListBox/tests.jsx
@@ -7,13 +7,12 @@
  *
  */
 
-/* global test jest */
-/* eslint-disable no-magic-numbers, no-multi-str*/
+/* eslint-disable no-magic-numbers */
 
 import React                 from 'react';
 import { shallow, mount }    from 'enzyme';
 
-import ListBox               from './index';
+import { ListBox }           from '../index';
 
 
 describe( 'ListBox', () =>

--- a/src/MessageBox/tests.jsx
+++ b/src/MessageBox/tests.jsx
@@ -7,14 +7,12 @@
  *
  */
 
-/* global test */
 /* eslint-disable no-magic-numbers */
 
-import React        from 'react';
-import { mount }    from 'enzyme';
+import React            from 'react';
+import { mount }        from 'enzyme';
 
-
-import MessageBox   from './index';
+import { MessageBox }   from '../index';
 
 describe( 'MessageBox', () =>
 {

--- a/src/ModalDialog/tests.jsx
+++ b/src/ModalDialog/tests.jsx
@@ -7,14 +7,12 @@
  *
  */
 
-/* global test jest */
-/* eslint-disable no-magic-numbers, no-multi-str*/
+/* eslint-disable no-magic-numbers */
 
+import React            from 'react';
+import { mount }        from 'enzyme';
 
-import React       from 'react';
-import { mount }   from 'enzyme';
-
-import ModalDialog from './index';
+import { ModalDialog }  from '../index';
 
 describe( 'ModalDialog', () =>
 {
@@ -63,15 +61,15 @@ describe( 'ModalDialog', () =>
         'should trigger `onClickOverlay` once callback when overlay clicked',
         () =>
         {
-            const callBack = jest.fn();
+            const onClickOverlay = jest.fn();
             const props = {
-                isVisible      : true,
-                onClickOverlay : callBack,
+                isVisible : true,
+                onClickOverlay,
             };
             wrapper = mount( <ModalDialog { ...props } /> );
 
             wrapper.driver().clickOverlay();
-            expect( callBack ).toHaveBeenCalledTimes( 1 );
+            expect( onClickOverlay ).toHaveBeenCalledTimes( 1 );
         },
     );
 
@@ -79,45 +77,45 @@ describe( 'ModalDialog', () =>
         'should trigger `onClickClose` once when close button is clicked',
         () =>
         {
-            const callBack = jest.fn();
+            const onClickClose = jest.fn();
             const props = {
-                isVisible    : true,
-                onClickClose : callBack,
-                type         : 'carousel',
+                isVisible : true,
+                onClickClose,
+                type      : 'carousel',
             };
             wrapper = mount( <ModalDialog { ...props } /> );
 
             wrapper.driver().clickClose();
-            expect( callBack ).toHaveBeenCalledTimes( 1 );
+            expect( onClickClose ).toHaveBeenCalledTimes( 1 );
         },
     );
 
     test( 'should trigger `onClickPrev` once when prev button is clicked', () =>
     {
-        const callBack = jest.fn();
+        const onClickPrev = jest.fn();
         const props = {
-            isVisible   : true,
-            onClickPrev : callBack,
-            type        : 'carousel',
+            isVisible : true,
+            onClickPrev,
+            type      : 'carousel',
         };
         wrapper = mount( <ModalDialog { ...props } /> );
 
         wrapper.driver().clickPrev();
-        expect( callBack ).toHaveBeenCalledTimes( 1 );
+        expect( onClickPrev ).toHaveBeenCalledTimes( 1 );
     } );
 
     test( 'should trigger `onClickNext` once when next button is clicked', () =>
     {
-        const callBack = jest.fn();
+        const onClickNext = jest.fn();
         const props = {
-            isVisible   : true,
-            onClickNext : callBack,
-            type        : 'carousel',
+            isVisible : true,
+            onClickNext,
+            type      : 'carousel',
         };
         wrapper = mount( <ModalDialog { ...props } /> );
 
         wrapper.driver().clickNext();
-        expect( callBack ).toHaveBeenCalledTimes( 1 );
+        expect( onClickNext ).toHaveBeenCalledTimes( 1 );
     } );
 
     describe( 'driver', () =>
@@ -125,10 +123,10 @@ describe( 'ModalDialog', () =>
         test( 'should throw an error when clicking the close button on a modal \
 that\'s not a carousel', () =>
         {
-            const callBack = jest.fn();
+            const onClickOverlay = jest.fn();
             const props = {
-                isVisible      : true,
-                onClickOverlay : callBack,
+                isVisible : true,
+                onClickOverlay,
             };
 
             wrapper = mount( <ModalDialog { ...props } /> );
@@ -136,16 +134,16 @@ that\'s not a carousel', () =>
             expect( () => wrapper.driver().clickClose() )
                 .toThrowError( 'Cannot trigger click on the "Close Button" \
 because the modal is not a Carousel' );
-            expect( callBack ).not.toBeCalled();
+            expect( onClickOverlay ).not.toBeCalled();
         } );
 
         test( 'should throw an error when clicking the prev button on a modal \
 that\'s not a carousel', () =>
         {
-            const callBack = jest.fn();
+            const onClickPrev = jest.fn();
             const props = {
-                isVisible   : true,
-                onClickPrev : callBack,
+                isVisible : true,
+                onClickPrev,
             };
 
             wrapper = mount( <ModalDialog { ...props } /> );
@@ -153,16 +151,16 @@ that\'s not a carousel', () =>
             expect( () => wrapper.driver().clickPrev() )
                 .toThrowError( 'Cannot trigger click on the "Prev Button" \
 because the modal is not a Carousel' );
-            expect( callBack ).not.toBeCalled();
+            expect( onClickPrev ).not.toBeCalled();
         } );
 
         test( 'should throw an error when clicking the next button on a modal \
 that\'s not a carousel', () =>
         {
-            const callBack = jest.fn();
+            const onClickNext = jest.fn();
             const props = {
-                isVisible   : true,
-                onClickNext : callBack,
+                isVisible : true,
+                onClickNext,
             };
 
             wrapper = mount( <ModalDialog { ...props } /> );
@@ -170,7 +168,7 @@ that\'s not a carousel', () =>
             expect( () => wrapper.driver().clickNext() )
                 .toThrowError( 'Cannot trigger click on the "Next Button" \
 because the modal is not a Carousel' );
-            expect( callBack ).not.toBeCalled();
+            expect( onClickNext ).not.toBeCalled();
         } );
     } );
 } );

--- a/src/Module/tests.jsx
+++ b/src/Module/tests.jsx
@@ -8,16 +8,12 @@
  *
  */
 
-/* global test jest */
-/* eslint-disable no-magic-numbers, no-multi-str*/
+/* eslint-disable no-magic-numbers */
 
-import React                       from 'react';
-import { mount, shallow }          from 'enzyme';
+import React                               from 'react';
+import { mount, shallow }                  from 'enzyme';
 
-import { H2, H3, IconWithTooltip } from '../index';
-
-import Module                      from './index';
-
+import { H2, H3, IconWithTooltip, Module } from '../index';
 
 describe( 'Module', () =>
 {

--- a/src/NavBar/tests.jsx
+++ b/src/NavBar/tests.jsx
@@ -7,14 +7,12 @@
  *
  */
 
-/* global test */
-/* eslint-disable no-magic-numbers, no-multi-str*/
-
+/* eslint-disable no-magic-numbers */
 
 import React        from 'react';
 import { mount }    from 'enzyme';
 
-import NavBar       from './index';
+import { NavBar }   from '../index';
 
 describe( 'NavBar', () =>
 {

--- a/src/NavDropdown/tests.jsx
+++ b/src/NavDropdown/tests.jsx
@@ -7,14 +7,12 @@
  *
  */
 
-/* global test */
-/* eslint-disable no-magic-numbers*/
+/* eslint-disable no-magic-numbers */
 
+import React            from 'react';
+import { mount }        from 'enzyme';
 
-import React        from 'react';
-import { mount }    from 'enzyme';
-
-import NavDropdown  from './index';
+import { NavDropdown }  from '../index';
 
 describe( 'NavDropdown', () =>
 {

--- a/src/NavItem/tests.jsx
+++ b/src/NavItem/tests.jsx
@@ -7,13 +7,12 @@
  *
  */
 
-/* global test jest */
-/* eslint-disable no-magic-numbers, no-multi-str, no-unused-expressions */
+/* eslint-disable no-magic-numbers */
 
-import React     from 'react';
-import { mount } from 'enzyme';
+import React        from 'react';
+import { mount }    from 'enzyme';
 
-import NavItem   from './index';
+import { NavItem }  from '../index';
 
 describe( 'NavItem', () =>
 {
@@ -60,7 +59,6 @@ describe( 'NavItemDriver', () =>
         } );
 
         driver.click();
-
         expect( onClickSpy ).toBeCalledTimes( 1 );
     } );
 
@@ -72,7 +70,6 @@ describe( 'NavItemDriver', () =>
         } );
 
         driver.mouseOver();
-
         expect( onMouseOverSpy ).toBeCalledTimes( 1 );
     } );
 
@@ -84,7 +81,6 @@ describe( 'NavItemDriver', () =>
         } );
 
         driver.mouseOut();
-
         expect( onMouseOutSpy ).toBeCalledTimes( 1 );
     } );
 } );

--- a/src/NavList/tests.jsx
+++ b/src/NavList/tests.jsx
@@ -7,13 +7,12 @@
  *
  */
 
-/* global test */
-/* eslint-disable no-magic-numbers*/
+/* eslint-disable no-magic-numbers */
 
 import React        from 'react';
 import { mount }    from 'enzyme';
 
-import NavList      from './index';
+import { NavList }  from '../index';
 
 describe( 'NavList', () =>
 {

--- a/src/NotificationBar/tests.jsx
+++ b/src/NotificationBar/tests.jsx
@@ -7,14 +7,12 @@
  *
  */
 
-/* global test */
-/* eslint-disable no-magic-numbers, no-multi-str, no-unused-expressions */
+/* eslint-disable no-magic-numbers */
 
+import React                from 'react';
+import { mount }            from 'enzyme';
 
-import React            from 'react';
-import { mount }        from 'enzyme';
-
-import NotificationBar  from './index';
+import { NotificationBar }  from '../index';
 
 describe( 'NotificationBar', () =>
 {

--- a/src/Paginator/tests.jsx
+++ b/src/Paginator/tests.jsx
@@ -7,12 +7,12 @@
  *
  */
 
-/* global test jest */
+/* eslint-disable no-magic-numbers */
 
-import React                    from 'react';
-import { mount }                from 'enzyme';
+import React            from 'react';
+import { mount }        from 'enzyme';
 
-import { Paginator }            from '../index';
+import { Paginator }    from '../index';
 
 describe( 'PaginatorDriver', () =>
 {
@@ -38,7 +38,6 @@ describe( 'PaginatorDriver', () =>
             } );
 
             driver.clickPrev();
-
             expect( onClickPrev ).toBeCalledTimes( 1 );
         } );
     } );
@@ -56,7 +55,6 @@ describe( 'PaginatorDriver', () =>
             } );
 
             driver.clickNext();
-
             expect( onClickNext ).toBeCalledTimes( 1 );
         } );
     } );
@@ -74,7 +72,6 @@ describe( 'PaginatorDriver', () =>
             } );
 
             driver.clickPage( 1 );
-
             expect( onClickPage ).toBeCalledTimes( 1 );
         } );
     } );

--- a/src/PasswordInput/tests.jsx
+++ b/src/PasswordInput/tests.jsx
@@ -7,16 +7,12 @@
  *
  */
 
-/* global test jest */
-/* eslint-disable no-unused-expressions, no-magic-numbers  */
+/* eslint-disable no-magic-numbers  */
 
-import React                    from 'react';
-import { mount, shallow }       from 'enzyme';
+import React                                from 'react';
+import { mount, shallow }                   from 'enzyme';
 
-import { TextInputWithIcon }    from '../index';
-
-import PasswordInput            from './index';
-
+import { PasswordInput, TextInputWithIcon } from '../index';
 
 describe( 'PasswordInput', () =>
 {

--- a/src/ProgressBar/tests.jsx
+++ b/src/ProgressBar/tests.jsx
@@ -7,13 +7,12 @@
  *
  */
 
-/* global test */
 /* eslint-disable no-magic-numbers  */
 
-import React        from 'react';
-import { mount }    from 'enzyme';
+import React            from 'react';
+import { mount }        from 'enzyme';
 
-import ProgressBar  from './index';
+import { ProgressBar }  from '../index';
 
 describe( 'ProgressBar', () =>
 {

--- a/src/ProgressIndicator/tests.jsx
+++ b/src/ProgressIndicator/tests.jsx
@@ -7,13 +7,12 @@
  *
  */
 
-/* global test */
 /* eslint-disable no-magic-numbers  */
 
-import React                from 'react';
-import { mount }            from 'enzyme';
+import React                    from 'react';
+import { mount }                from 'enzyme';
 
-import ProgressIndicator    from './index';
+import { ProgressIndicator }    from '../index';
 
 describe( 'ProgressIndicator', () =>
 {

--- a/src/Radio/tests.jsx
+++ b/src/Radio/tests.jsx
@@ -7,15 +7,13 @@
  *
  */
 
-/* global test jest */
-/* eslint-disable no-magic-numbers, no-unused-expressions */
+/* eslint-disable no-magic-numbers */
 
 import React              from 'react';
 import { shallow, mount } from 'enzyme';
 
 import Checkable          from '../proto/Checkable';
-
-import Radio              from './index';
+import { Radio }          from '../index';
 
 
 describe( 'Radio', () =>

--- a/src/RadioGroup/tests.jsx
+++ b/src/RadioGroup/tests.jsx
@@ -7,13 +7,12 @@
  *
  */
 
-/* eslint-disable no-magic-numbers, no-multi-str, no-unused-expressions */
-/* global test jest */
+/* eslint-disable no-magic-numbers */
 
-import React      from 'react';
-import { mount }  from 'enzyme';
+import React            from 'react';
+import { mount }        from 'enzyme';
 
-import RadioGroup from './index';
+import { RadioGroup }   from '../index';
 
 describe( 'RadioGroupDriver', () =>
 {

--- a/src/Required/tests.jsx
+++ b/src/Required/tests.jsx
@@ -7,8 +7,7 @@
  *
  */
 
-/* global test */
-/* eslint-disable no-magic-numbers, no-multi-str, no-unused-expressions */
+/* eslint-disable no-magic-numbers */
 
 import React        from 'react';
 import { mount }    from 'enzyme';

--- a/src/ScrollBar/tests.jsx
+++ b/src/ScrollBar/tests.jsx
@@ -7,13 +7,12 @@
  *
  */
 
-/* global test jest */
-
+/* eslint-disable no-magic-numbers */
 
 import React               from 'react';
 import { mount, shallow }  from 'enzyme';
 
-import ScrollBar           from './index';
+import { ScrollBar }       from '../index';
 
 describe( 'ScrollBar', () =>
 {

--- a/src/ScrollBox/tests.jsx
+++ b/src/ScrollBox/tests.jsx
@@ -7,17 +7,13 @@
  *
  */
 
-/* global test jest */
-/* eslint-disable no-magic-numbers, no-multi-str */
+/* eslint-disable no-magic-numbers */
 
-import React              from 'react';
-import { mount, shallow } from 'enzyme';
+import React                    from 'react';
+import { mount, shallow }       from 'enzyme';
 
-import ScrollBar          from '../ScrollBar';
-import * as utils         from './utils';
-
-import ScrollBox          from './index';
-
+import { ScrollBar, ScrollBox } from '../index';
+import * as utils               from './utils';
 
 describe( 'ScrollBox', () =>
 {
@@ -128,7 +124,6 @@ describe( 'ScrollBoxDriver', () =>
             wrapper.setProps( { onClickScrollUp, scrollUpIsVisible: true } );
 
             wrapper.driver().clickScrollUp();
-
             expect( onClickScrollUp ).toBeCalledTimes( 1 );
         } );
 
@@ -141,7 +136,6 @@ describe( 'ScrollBoxDriver', () =>
             } );
 
             wrapper.driver().clickScrollRight();
-
             expect( onClickScrollRight ).toBeCalledTimes( 1 );
         } );
 
@@ -155,7 +149,6 @@ describe( 'ScrollBoxDriver', () =>
             } );
 
             wrapper.driver().clickScrollDown();
-
             expect( onClickScrollDown ).toBeCalledTimes( 1 );
         } );
 
@@ -169,7 +162,6 @@ describe( 'ScrollBoxDriver', () =>
             } );
 
             wrapper.driver().clickScrollLeft();
-
             expect( onClickScrollLeft ).toBeCalledTimes( 1 );
         } );
 
@@ -181,7 +173,6 @@ describe( 'ScrollBoxDriver', () =>
             } );
 
             wrapper.driver().clickScrollUp();
-
             expect( instance.innerRef.scrollTop ).toBe( 0 );
         } );
 
@@ -193,7 +184,6 @@ describe( 'ScrollBoxDriver', () =>
             } );
 
             wrapper.driver().clickScrollRight();
-
             expect( instance.innerRef.scrollLeft ).toBe( 100 );
         } );
 
@@ -205,7 +195,6 @@ describe( 'ScrollBoxDriver', () =>
             } );
 
             wrapper.driver().clickScrollDown();
-
             expect( instance.innerRef.scrollTop ).toBe( 100 );
         } );
 
@@ -217,7 +206,6 @@ describe( 'ScrollBoxDriver', () =>
             } );
 
             wrapper.driver().clickScrollLeft();
-
             expect( instance.innerRef.scrollLeft ).toBe( 0 );
         } );
     } );
@@ -230,7 +218,6 @@ describe( 'ScrollBoxDriver', () =>
             wrapper.setProps( { onScroll, scroll: 'vertical' } );
 
             wrapper.driver().scrollVertical( 250 );
-
             expect( onScroll ).toBeCalledTimes( 1 );
         } );
 
@@ -254,7 +241,6 @@ neither \'vertical\' nor \'both\'' );
             wrapper.setProps( { onScroll, scroll: 'horizontal' } );
 
             wrapper.driver().scrollHorizontal( 250 );
-
             expect( onScroll ).toBeCalledTimes( 1 );
         } );
 

--- a/src/Section/tests.jsx
+++ b/src/Section/tests.jsx
@@ -7,15 +7,12 @@
  *
  */
 
-/* global test */
+/* eslint-disable no-magic-numbers */
 
-import React       from 'react';
-import { shallow } from 'enzyme';
+import React                from 'react';
+import { shallow }          from 'enzyme';
 
-import { H1, H4 }  from '../index';
-
-import Section     from './index';
-
+import { H1, H4, Section }  from '../index';
 
 describe( 'Section', () =>
 {

--- a/src/Slider/tests.jsx
+++ b/src/Slider/tests.jsx
@@ -7,16 +7,12 @@
  *
  */
 
-/* global test jest */
-/* eslint-disable no-magic-numbers, no-multi-str, no-unused-expressions */
+/* eslint-disable no-magic-numbers */
 
+import React                from 'react';
+import { mount }            from 'enzyme';
 
-import React        from 'react';
-import { mount }    from 'enzyme';
-
-import Label        from '../Label/index';
-
-import Slider       from './index';
+import { Label, Slider }    from '../index';
 
 const noop = () => null;
 

--- a/src/SliderGroup/tests.jsx
+++ b/src/SliderGroup/tests.jsx
@@ -7,16 +7,12 @@
  *
  */
 
-/* global test jest */
-/* eslint-disable max-len */
+/* eslint-disable no-magic-numbers */
 
-import React             from 'react';
-import { mount }         from 'enzyme';
+import React                          from 'react';
+import { mount }                      from 'enzyme';
 
-import { Label, Slider } from '../index';
-
-import SliderGroup       from './index';
-
+import { Label, Slider, SliderGroup } from '../index';
 
 describe( 'SliderGroup', () =>
 {
@@ -89,7 +85,8 @@ describe( 'SliderGroup', () =>
     } );
 
     test(
-        'Step labels should pass to the individual Sliders the correct amount of ticks',
+        'Step labels should pass to the individual Sliders the correct amount \
+of ticks',
         () =>
         {
             const props = {
@@ -173,7 +170,8 @@ describe( 'SliderGroup', () =>
     } );
 
     test(
-        'SliderGroup should pass down its isReadOnly/isDisabled/hasError prop to the individual sliders if defined',
+        'SliderGroup should pass down its isReadOnly/isDisabled/hasError prop \
+to the individual sliders if defined',
         () =>
         {
             const props = {
@@ -195,7 +193,8 @@ describe( 'SliderGroup', () =>
     );
 
     test(
-        'SliderGroup should pass down its minValue and maxValue prop to the individual sliders if defined',
+        'SliderGroup should pass down its minValue and maxValue prop to the \
+individual sliders if defined',
         () =>
         {
             const props = {
@@ -211,7 +210,8 @@ describe( 'SliderGroup', () =>
     );
 
     test(
-        'Individual sliders should get their orientation = vertical even if the a orientation is individually passed as horizontal in sliders array ',
+        'Individual sliders should get their orientation = vertical even if \
+the a orientation is individually passed as horizontal in sliders array ',
         () =>
         {
             const props = {
@@ -264,7 +264,8 @@ describe( 'SliderGroupDriver', () =>
         } );
 
         test(
-            'Individual slider onChange event should also trigger SliderGroup onChange event if the function is provided in proptype OnChange',
+            'Individual slider onChange event should also trigger SliderGroup \
+onChange event if the function is provided in proptype OnChange',
             () =>
             {
                 const onChangeSlider = jest.fn();

--- a/src/Sorter/tests.jsx
+++ b/src/Sorter/tests.jsx
@@ -7,12 +7,12 @@
  *
  */
 
-/* global test jest */
+/* eslint-disable no-magic-numbers */
 
-import React     from 'react';
-import { mount } from 'enzyme';
+import React        from 'react';
+import { mount }    from 'enzyme';
 
-import Sorter    from './index';
+import { Sorter }   from '../index';
 
 describe( 'Sorter', () =>
 {
@@ -54,7 +54,6 @@ describe( 'SorterDriver', () =>
         } );
 
         driver.click();
-
         expect( onToggle ).toBeCalledTimes( 1 );
     } );
 } );

--- a/src/Spinner/tests.jsx
+++ b/src/Spinner/tests.jsx
@@ -7,13 +7,12 @@
  *
  */
 
-/* global test */
 /* eslint-disable no-magic-numbers */
 
 import React        from 'react';
 import { mount }    from 'enzyme';
 
-import Spinner      from './index';
+import { Spinner }  from '../index';
 
 describe( 'Spinner', () =>
 {

--- a/src/SpriteMap/tests.jsx
+++ b/src/SpriteMap/tests.jsx
@@ -7,13 +7,12 @@
  *
  */
 
-/* eslint-disable no-magic-numbers, no-multi-str, no-unused-expressions */
-/* global test */
+/* eslint-disable no-magic-numbers */
 
-import React       from 'react';
-import { shallow } from 'enzyme';
+import React            from 'react';
+import { shallow }      from 'enzyme';
 
-import SpriteMap   from './index';
+import { SpriteMap }    from '../index';
 
 
 describe( 'SpriteMap', () =>

--- a/src/StatusIndicator/tests.jsx
+++ b/src/StatusIndicator/tests.jsx
@@ -7,13 +7,12 @@
  *
  */
 
-/* global test */
 /* eslint-disable no-magic-numbers */
 
-import React            from 'react';
-import { mount }        from 'enzyme';
+import React                from 'react';
+import { mount }            from 'enzyme';
 
-import StatusIndicator  from './index';
+import { StatusIndicator }  from '../index';
 
 describe( 'StatusIndicator', () =>
 {

--- a/src/Switch/tests.jsx
+++ b/src/Switch/tests.jsx
@@ -7,14 +7,12 @@
  *
  */
 
-/* global test jest */
 /* eslint-disable no-magic-numbers */
-/* eslint-disable no-return-assign */
 
 import React                from 'react';
 import { mount, shallow }   from 'enzyme';
 
-import Switch               from './index';
+import { Switch }           from '../index';
 
 describe( 'Switch', () =>
 {

--- a/src/Tab/tests.jsx
+++ b/src/Tab/tests.jsx
@@ -1,9 +1,18 @@
-/* global test jest */
+/*
+ * Copyright (c) 2018 dunnhumby Germany GmbH.
+ * All rights reserved.
+ *
+ * This source code is licensed under the MIT license found in the LICENSE file
+ * in the root directory of this source tree.
+ *
+ */
+
+/* eslint-disable no-magic-numbers */
 
 import React       from 'react';
 import { mount }   from 'enzyme';
 
-import Tab         from './index';
+import { Tab }     from '../index';
 
 describe( 'TabDriver', () =>
 {
@@ -21,11 +30,9 @@ describe( 'TabDriver', () =>
         test( 'should trigger onClick callback function', () =>
         {
             const onClick = jest.fn();
-
             wrapper.setProps( { onClick } );
 
             driver.click();
-
             expect( onClick ).toBeCalled();
         } );
     } );

--- a/src/TabButton/tests.jsx
+++ b/src/TabButton/tests.jsx
@@ -7,7 +7,7 @@
  *
  */
 
-/* global test jest */
+/* eslint-disable no-magic-numbers */
 
 import React            from 'react';
 import { mount }        from 'enzyme';

--- a/src/Table/tests.jsx
+++ b/src/Table/tests.jsx
@@ -1,10 +1,18 @@
-/* global test jest */
+/*
+ * Copyright (c) 2018 dunnhumby Germany GmbH.
+ * All rights reserved.
+ *
+ * This source code is licensed under the MIT license found in the LICENSE file
+ * in the root directory of this source tree.
+ *
+ */
+
+/* eslint-disable no-magic-numbers */
 
 import React        from 'react';
 import { mount }    from 'enzyme';
 
-import Table        from './index';
-
+import { Table }    from '../index';
 
 describe( 'TableDriver', () =>
 {
@@ -44,7 +52,6 @@ describe( 'TableDriver', () =>
             () =>
             {
                 const onToggle = jest.fn();
-
                 wrapper.setProps( { onToggle } );
 
                 driver.toggle();
@@ -70,7 +77,6 @@ not sortable';
         test( 'should trigger onMouseOver callback once', () =>
         {
             const onMouseOver = jest.fn();
-
             wrapper.setProps( { onMouseOver } );
 
             driver.mouseOver();
@@ -84,7 +90,6 @@ not sortable';
         test( 'should trigger onMouseOut callback once', () =>
         {
             const onMouseOut = jest.fn();
-
             wrapper.setProps( { onMouseOut } );
 
             driver.mouseOut();

--- a/src/TableCell/tests.jsx
+++ b/src/TableCell/tests.jsx
@@ -1,9 +1,18 @@
-/* global test jest */
+/*
+ * Copyright (c) 2018 dunnhumby Germany GmbH.
+ * All rights reserved.
+ *
+ * This source code is licensed under the MIT license found in the LICENSE file
+ * in the root directory of this source tree.
+ *
+ */
 
-import React       from 'react';
-import { mount }   from 'enzyme';
+/* eslint-disable no-magic-numbers */
 
-import TableCell   from './index';
+import React            from 'react';
+import { mount }        from 'enzyme';
+
+import { TableCell }    from '../index';
 
 describe( 'TableCellDriver', () =>
 {
@@ -29,7 +38,6 @@ describe( 'TableCellDriver', () =>
             } );
 
             driver.toggle();
-
             expect( onToggle ).toBeCalledTimes( 1 );
         } );
 

--- a/src/Tabs/tests.jsx
+++ b/src/Tabs/tests.jsx
@@ -7,16 +7,12 @@
  *
  */
 
-/* global test */
-/* eslint-disable no-magic-numbers, no-multi-str*/
+/* eslint-disable no-magic-numbers */
 
-import React              from 'react';
-import { shallow, mount } from 'enzyme';
+import React                    from 'react';
+import { shallow, mount }       from 'enzyme';
 
-import { Tab, TabButton } from '../index';
-
-import Tabs               from './index';
-
+import { Tab, TabButton, Tabs } from '../index';
 
 describe( 'Tabs', () =>
 {

--- a/src/Tag/tests.jsx
+++ b/src/Tag/tests.jsx
@@ -7,16 +7,12 @@
  *
  */
 
-/* global test jest */
-/* eslint-disable no-magic-numbers, no-multi-str, no-unused-expressions */
+/* eslint-disable no-magic-numbers */
 
-import React        from 'react';
-import { mount }    from 'enzyme';
+import React                from 'react';
+import { mount }            from 'enzyme';
 
-import IconButton   from '../IconButton';
-
-import Tag          from './index';
-
+import { IconButton, Tag }  from '../index';
 
 describe( 'Tag', () =>
 {

--- a/src/TagInput/tests.jsx
+++ b/src/TagInput/tests.jsx
@@ -7,16 +7,12 @@
  *
  */
 
-/* global test jest */
-/* eslint-disable no-magic-numbers, no-multi-str, no-unused-expressions */
+/* eslint-disable no-magic-numbers */
 
 import React              from 'react';
 import { mount, shallow } from 'enzyme';
 
-import { Tag }            from '../index';
-
-import TagInput           from './index';
-
+import { Tag, TagInput }  from '../index';
 
 describe( 'TagInput', () =>
 {

--- a/src/Text/tests.jsx
+++ b/src/Text/tests.jsx
@@ -7,13 +7,12 @@
  *
  */
 
-/* global test */
 /* eslint-disable no-magic-numbers */
 
 import React        from 'react';
 import { mount }    from 'enzyme';
 
-import Text         from './index';
+import { Text }     from '../index';
 
 describe( 'Text', () =>
 {

--- a/src/TextArea/tests.jsx
+++ b/src/TextArea/tests.jsx
@@ -7,17 +7,13 @@
  *
  */
 
-/* global test */
-/* eslint-disable no-magic-numbers, no-multi-str, no-unused-expressions */
+/* eslint-disable no-magic-numbers */
 
-import React              from 'react';
-import { shallow, mount } from 'enzyme';
+import React                    from 'react';
+import { shallow, mount }       from 'enzyme';
 
-import { InputField }     from '../index';
-import InputContainer     from '../proto/InputContainer';
-
-import TextArea           from './index';
-
+import { InputField, TextArea } from '../index';
+import InputContainer           from '../proto/InputContainer';
 
 describe( 'TextArea', () =>
 {

--- a/src/TextInput/tests.jsx
+++ b/src/TextInput/tests.jsx
@@ -7,17 +7,13 @@
  *
  */
 
-/* global test jest */
-/* eslint-disable no-magic-numbers, no-multi-str, no-unused-expressions */
+/* eslint-disable no-magic-numbers */
 
-import React              from 'react';
-import { mount, shallow } from 'enzyme';
+import React                        from 'react';
+import { mount, shallow }           from 'enzyme';
 
-import { InputField }     from '../index';
-import InputContainer     from '../proto/InputContainer';
-
-import TextInput          from './index';
-
+import { InputField, TextInput }    from '../index';
+import InputContainer               from '../proto/InputContainer';
 
 describe( 'TextInput', () =>
 {

--- a/src/TextInputWithDropdown/tests.jsx
+++ b/src/TextInputWithDropdown/tests.jsx
@@ -7,17 +7,17 @@
  *
  */
 
-/* global test */
 /* eslint-disable no-magic-numbers */
 
-import React                             from 'react';
-import { shallow, mount }                from 'enzyme';
+import React                from 'react';
+import { shallow, mount }   from 'enzyme';
 
-import { InputField, FlounderDropdown }  from '../index';
-import InputContainer                    from '../proto/InputContainer';
-
-import TextInputWithDropdown             from './index';
-
+import {
+    InputField,
+    FlounderDropdown,
+    TextInputWithDropdown,
+} from '../index';
+import InputContainer   from '../proto/InputContainer';
 
 describe( 'TextInputWithDropdown', () =>
 {

--- a/src/TextInputWithIcon/tests.jsx
+++ b/src/TextInputWithIcon/tests.jsx
@@ -7,8 +7,7 @@
  *
  */
 
-/* global test jest Event */
-/* eslint-disable no-magic-numbers, no-multi-str, no-unused-expressions */
+/* eslint-disable no-magic-numbers */
 
 import React               from 'react';
 import { shallow, mount }  from 'enzyme';
@@ -16,12 +15,10 @@ import { shallow, mount }  from 'enzyme';
 import {
     IconButton,
     InputField,
+    TextInputWithIcon,
     TextInputWithIcon as WrappedTextInputWithIcon,
     Tooltip,
 } from '../index';
-
-import TextInputWithIcon from './index';
-
 
 describe( 'TextInputWithIcon', () =>
 {

--- a/src/ToggleButton/tests.jsx
+++ b/src/ToggleButton/tests.jsx
@@ -7,16 +7,12 @@
  *
  */
 
-/* global jest, test */
-/* eslint-disable no-magic-numbers, no-multi-str, no-unused-expressions */
+/* eslint-disable no-magic-numbers */
 
-import React               from 'react';
-import { shallow, mount }  from 'enzyme';
+import React                    from 'react';
+import { shallow, mount }       from 'enzyme';
 
-import { Icon }            from '../index';
-
-import ToggleButton        from './index';
-
+import { Icon, ToggleButton }   from '../index';
 
 describe( 'ToggleButton', () =>
 {

--- a/src/Tooltip/tests.jsx
+++ b/src/Tooltip/tests.jsx
@@ -7,13 +7,12 @@
  *
  */
 
-/* global test jest */
-/* eslint-disable no-magic-numbers, no-multi-str, no-unused-expressions */
+/* eslint-disable no-magic-numbers */
 
-import React     from 'react';
-import { mount } from 'enzyme';
+import React        from 'react';
+import { mount }    from 'enzyme';
 
-import Tooltip   from './index';
+import { Tooltip }  from '../index';
 
 
 describe( 'TooltipDriver', () =>

--- a/src/Uploader/tests.jsx
+++ b/src/Uploader/tests.jsx
@@ -7,14 +7,12 @@
  *
  */
 
-/* global test jest */
-/* eslint-disable no-magic-numbers, no-multi-str, no-unused-expressions */
+/* eslint-disable no-magic-numbers */
 
+import React        from 'react';
+import { mount }    from 'enzyme';
 
-import React                      from 'react';
-import { mount }                  from 'enzyme';
-
-import Uploader                   from './index';
+import { Uploader } from '../index';
 
 describe( 'Uploader', () =>
 {

--- a/src/ValuedTextInput/tests.jsx
+++ b/src/ValuedTextInput/tests.jsx
@@ -7,18 +7,13 @@
  *
  */
 
-/* global test */
-/* eslint-disable no-magic-numbers, no-multi-str, no-unused-expressions */
+/* eslint-disable no-magic-numbers */
 
-import React                from 'react';
-import { shallow, mount }   from 'enzyme';
+import React                            from 'react';
+import { shallow, mount }               from 'enzyme';
 
-import { InputField }       from '../index';
-import InputContainer       from '../proto/InputContainer';
-
-
-import ValuedTextInput      from './index';
-
+import { InputField, ValuedTextInput }  from '../index';
+import InputContainer                   from '../proto/InputContainer';
 
 describe( 'ValuedTextInput', () =>
 {


### PR DESCRIPTION
For #468;

- removed `/* global … */` rules from tests
- left `/* eslint-disable no-magic-numbers */` to prevent linter from complaining
- updated imports in tests so that components are imported from main `index.js`