### PR TITLE
Issue 788 grid overflow

### DIFF
--- a/src/Grid/grid.css
+++ b/src/Grid/grid.css
@@ -18,14 +18,7 @@
 
 .default
 {
-    display:        grid;
-    max-width:      100%;
-
-    > *
-    {
-        overflow:   hidden;
-        min-width:  0;
-    }
+    display:    grid;
 }
 
 


### PR DESCRIPTION
Closes #788:
- Removes `overflow: hidden` and `min-width: 0` from grid children
- Removes redundant `max-width: 100%` from grid itself (this is set in `base.css` anyways)