### PR TITLE
Update Grid defaults #796

### DIFF
--- a/src/Grid/README.md
+++ b/src/Grid/README.md
@@ -108,8 +108,8 @@ The props accept one of four values: `"S"`, `"M"` (default), `"L"` and `"none"`
 
 #### Horizontal alignment
 
-The Grid’s `justify` prop accepts one of four values: `"stretch"`,
-`"start"` (default), `"end"` and `"center"`.
+The Grid’s `justify` prop accepts one of four values: `"stretch"` (default),
+`"start"`, `"end"` and `"center"`.
 
 Aligns grid items along the inline (row) axis. This value applies to all grid
 items inside the container.
@@ -117,8 +117,8 @@ items inside the container.
 
 #### Vertical alignment
 
-The Grid’s `align` prop accepts one of four values: `"stretch"`, `"start"`
-(default), `"center"` and `"end"`.
+The Grid’s `align` prop accepts one of four values: `"stretch"` (default),
+`"start"`, `"center"` and `"end"`.
 
 Aligns grid items along the block (column) axis. This value applies to all grid
 items inside the container.

--- a/src/Grid/index.jsx
+++ b/src/Grid/index.jsx
@@ -93,7 +93,7 @@ export default class Grid extends React.Component
 
     static defaultProps =
     {
-        align         : 'start',
+        align         : 'stretch',
         autoCols      : undefined,
         autoFlow      : 'row',
         autoRows      : undefined,
@@ -104,7 +104,7 @@ export default class Grid extends React.Component
         cssMap        : undefined,
         customColumns : undefined,
         customRows    : undefined,
-        justify       : 'start',
+        justify       : 'stretch',
         rowGap        : 'M',
         rows          : undefined,
     };
@@ -129,8 +129,8 @@ export default class Grid extends React.Component
                 { ...attachEvents( this.props ) }
                 className = { cssMap.main }
                 style     = { {
-                    gridAutoColumns     : autoCols || '1fr',
-                    gridAutoRows        : autoRows || '1fr',
+                    gridAutoColumns     : autoCols,
+                    gridAutoRows        : autoRows,
                     gridTemplateColumns : customColumns ||
                         `repeat( ${columns}, 1fr )`,
                     gridTemplateRows : customRows || `repeat( ${rows}, 1fr )`,


### PR DESCRIPTION
Closes #796:
- `align-items` and `justify-items` are now `stretch` by default
- when `autoFlow` is `row`, `auto-rows` is unset by default (i.e. `auto`)
- when `autoFlow` is `column`, `auto-columns` is unset by default (i.e. `auto`)
- updated README