### PR TITLE
Issue 818 icon color

### DIFF
--- a/src/Icon/icon.css
+++ b/src/Icon/icon.css
@@ -44,7 +44,7 @@
 
 .role__default
 {
-    color:  var( --PC-GREY--D25 );
+    color:  inherit;
 }
 
 .role__critical


### PR DESCRIPTION
Closes #818:
- Icon now inherits current text color by default