### PR TITLE
Restore uncontrolled inputs #866

### DIFF
--- a/src/Checkbox/index.jsx
+++ b/src/Checkbox/index.jsx
@@ -26,58 +26,63 @@ export default class Checkbox extends React.Component
         /**
          *  Label content (React node; overrides label prop)
          */
-        children   : PropTypes.node,
+        children         : PropTypes.node,
         /**
          *  Extra CSS class name
          */
-        className  : PropTypes.string,
+        className        : PropTypes.string,
         /**
          *  CSS class map
          */
-        cssMap     : PropTypes.objectOf( PropTypes.string ),
+        cssMap           : PropTypes.objectOf( PropTypes.string ),
         /**
          *  Display as error/invalid
          */
-        hasError   : PropTypes.bool,
+        hasError         : PropTypes.bool,
         /**
          *  Component id
          */
-        id         : PropTypes.string,
+        id               : PropTypes.string,
         /**
          *  Display as checked (controlled input)
          */
-        isChecked  : PropTypes.bool,
+        isChecked        : PropTypes.bool,
+        /**
+         *  Display as checked by default (uncontrolled input)
+         */
+        isDefaultChecked : PropTypes.bool,
         /**
          *  Display as disabled
          */
-        isDisabled : PropTypes.bool,
+        isDisabled       : PropTypes.bool,
         /**
          *  Label content (string)
          */
-        label      : PropTypes.string,
+        label            : PropTypes.string,
         /**
          *  change callback prop
          */
-        onChange   : PropTypes.func,
+        onChange         : PropTypes.func,
         /**
          *  click callback prop
          */
-        onClick    : PropTypes.func,
+        onClick          : PropTypes.func,
 
     };
 
     static defaultProps =
     {
-        children   : undefined,
-        className  : undefined,
-        cssMap     : undefined,
-        hasError   : false,
-        id         : undefined,
-        isChecked  : undefined,
-        isDisabled : false,
-        label      : undefined,
-        onChange   : undefined,
-        onClick    : undefined,
+        children         : undefined,
+        className        : undefined,
+        cssMap           : undefined,
+        hasError         : false,
+        id               : undefined,
+        isChecked        : undefined,
+        isDefaultChecked : undefined,
+        isDisabled       : false,
+        label            : undefined,
+        onChange         : undefined,
+        onClick          : undefined,
     };
 
     static displayName = 'Checkbox';
@@ -89,6 +94,7 @@ export default class Checkbox extends React.Component
             cssMap = createCssMap( this.context.Checkbox, this.props ),
             id = generateId( 'Checkbox' ),
             isChecked,
+            isDefaultChecked,
             isDisabled,
             label,
         } = this.props;
@@ -106,11 +112,12 @@ export default class Checkbox extends React.Component
                 { ...attachEvents( this.props ) }
                 className = { cssMap.main }>
                 <input
-                    checked   = { isChecked }
-                    className = { cssMap.input }
-                    disabled  = { isDisabled }
-                    id        = { id }
-                    type      =  "checkbox" />
+                    checked        = { isChecked }
+                    className      = { cssMap.input }
+                    defaultChecked = { isDefaultChecked }
+                    disabled       = { isDisabled }
+                    id             = { id }
+                    type           =  "checkbox" />
                 <label className = { cssMap.label } htmlFor = { id }>
                     { labelContent &&
                         <span className = { cssMap.labelContent }>

--- a/src/CurrencyInput/index.jsx
+++ b/src/CurrencyInput/index.jsx
@@ -9,16 +9,17 @@
 
 /* global navigator */
 
-import React                                     from 'react';
-import PropTypes                                 from 'prop-types';
+import React            from 'react';
+import PropTypes        from 'prop-types';
 
-import { generateId }                            from '../utils';
+import { generateId }   from '../utils';
 
-import { TextInput }                             from '..';
+import { TextInput }    from '..';
 
 
 const currencyFormat = ( number, currency, language = navigator.language ) =>
-    number.toLocaleString( language, currency ? { style: 'currency', currency } : {} );
+    number.toLocaleString( language, currency ?
+        { style: 'currency', currency } : {} );
 
 export default class CurrencyInput extends React.Component
 {
@@ -27,102 +28,107 @@ export default class CurrencyInput extends React.Component
         /**
          *  Extra CSS class name
          */
-        className   : PropTypes.string,
+        className    : PropTypes.string,
         /**
          *  CSS class map
          */
-        cssMap      : PropTypes.objectOf( PropTypes.string ),
+        cssMap       : PropTypes.objectOf( PropTypes.string ),
         /**
          *  Currency to display
          */
-        currency    : PropTypes.oneOf( [ 'USD', 'EUR', 'GBP' ] ),
+        currency     : PropTypes.oneOf( [ 'USD', 'EUR', 'GBP' ] ),
+        /**
+         *  Default input string value
+         */
+        defaultValue : PropTypes.string,
         /**
          *  Display as error/invalid
          */
-        hasError    : PropTypes.bool,
+        hasError     : PropTypes.bool,
         /**
          *  HTML id attribute
          */
-        id          : PropTypes.string,
+        id           : PropTypes.string,
         /**
          *  Display as disabled
          */
-        isDisabled  : PropTypes.bool,
+        isDisabled   : PropTypes.bool,
         /**
          *  Display as read-only
          */
-        isReadOnly  : PropTypes.bool,
+        isReadOnly   : PropTypes.bool,
         /**
          *  Blur callback function
          */
-        onBlur      : PropTypes.func,
+        onBlur       : PropTypes.func,
         /**
          *  Input change callback function
          */
-        onChange    : PropTypes.func,
+        onChange     : PropTypes.func,
         /**
          *  Input click callback function
          */
-        onClick     : PropTypes.func,
+        onClick      : PropTypes.func,
         /**
          *  Focus callback function
          */
-        onFocus     : PropTypes.func,
+        onFocus      : PropTypes.func,
         /**
          *  Key down callback function
          */
-        onKeyDown   : PropTypes.func,
+        onKeyDown    : PropTypes.func,
         /**
          *  Key press callback function
          */
-        onKeyPress  : PropTypes.func,
+        onKeyPress   : PropTypes.func,
         /**
          *  Key up callback function
          */
-        onKeyUp     : PropTypes.func,
+        onKeyUp      : PropTypes.func,
         /**
          *  Mouse out callback function
          */
-        onMouseOut  : PropTypes.func,
+        onMouseOut   : PropTypes.func,
         /**
          *  Mouse over  callback function
          */
-        onMouseOver : PropTypes.func,
+        onMouseOver  : PropTypes.func,
         /**
          *  Placeholder text
          */
-        placeholder : PropTypes.string,
+        placeholder  : PropTypes.string,
         /**
          *  Input text alignment
          */
-        textAlign   : PropTypes.oneOf( [ 'left', 'right' ] ),
+        textAlign    : PropTypes.oneOf( [ 'left', 'right' ] ),
         /**
          *  Input string value
          */
-        value       : PropTypes.string,
+        value        : PropTypes.string,
     };
 
     static defaultProps =
     {
-        className   : undefined,
-        cssMap      : undefined,
-        currency    : undefined,
-        hasError    : false,
-        id          : undefined,
-        isDisabled  : false,
-        isReadOnly  : false,
-        onBlur      : undefined,
-        onChange    : undefined,
-        onClick     : undefined,
-        onFocus     : undefined,
-        onKeyDown   : undefined,
-        onKeyPress  : undefined,
-        onKeyUp     : undefined,
-        onMouseOut  : undefined,
-        onMouseOver : undefined,
-        placeholder : undefined,
-        textAlign   : 'left',
-        value       : '',
+        className    : undefined,
+        cssMap       : undefined,
+        currency     : undefined,
+        defaultValue : '',
+        hasError     : false,
+        id           : undefined,
+        isDisabled   : false,
+        isReadOnly   : false,
+        onBlur       : undefined,
+        onChange     : undefined,
+        onClick      : undefined,
+        onFocus      : undefined,
+        onKeyDown    : undefined,
+        onKeyPress   : undefined,
+        onKeyUp      : undefined,
+        onMouseOut   : undefined,
+        onMouseOver  : undefined,
+        placeholder  : undefined,
+        textAlign    : 'left',
+        value        : '',
     };
 
 
@@ -140,7 +146,8 @@ export default class CurrencyInput extends React.Component
 
     handleBlur()
     {
-        const newVal = Number( String( this.state.value ).replace( /[^0-9\.-]/g, '' ) );
+        const newVal = Number( String( this.state.value )
+            .replace( /[^0-9\.-]/g, '' ) );
         this.setState( {
             value : newVal,
         } );
@@ -165,20 +172,29 @@ export default class CurrencyInput extends React.Component
     {
         const {
             currency,
+            defaultValue,
             id = generateId( 'CurrencyInput' ),
             value,
         } = this.props;
+
+        const currencyDefaultValue =
+            Number( defaultValue.replace( /[^0-9\.-]/g, '' ) );
+        const currencyValue = Number( value.replace( /[^0-9\.-]/g, '' ) );
+
         return (
             <TextInput
                 { ...this.props }
                 autoCapitalize = "off"
                 autoComplete   = "off"
                 autoCorrect    = "off"
-                spellCheck     = { false }
+                defaultValue   = { currencyFormat( currencyDefaultValue,
+                    currency ) }
                 id             = { id }
                 onBlur         = { this.handleBlur }
                 onChange       = { this.handleChange }
-                value          = { currencyFormat( Number( value.replace( /[^0-9\.-]/g, '' ) ) || this.state.value, currency ) } />
+                spellCheck     = { false }
+                value          = { currencyFormat( currencyValue ||
+                    this.state.value, currency ) } />
         );
     }
 }

--- a/src/CurrencyInput/index.jsx
+++ b/src/CurrencyInput/index.jsx
@@ -112,7 +112,7 @@ export default class CurrencyInput extends React.Component
         className    : undefined,
         cssMap       : undefined,
         currency     : undefined,
-        defaultValue : undefined,
+        defaultValue : '',
         hasError     : false,
         id           : undefined,
         isDisabled   : false,
@@ -128,9 +128,8 @@ export default class CurrencyInput extends React.Component
         onMouseOver  : undefined,
         placeholder  : undefined,
         textAlign    : 'left',
-        value        : undefined,
+        value        : '',
     };
-
 
     static displayName = 'CurrencyInput';
 

--- a/src/CurrencyInput/index.jsx
+++ b/src/CurrencyInput/index.jsx
@@ -112,7 +112,7 @@ export default class CurrencyInput extends React.Component
         className    : undefined,
         cssMap       : undefined,
         currency     : undefined,
-        defaultValue : '',
+        defaultValue : undefined,
         hasError     : false,
         id           : undefined,
         isDisabled   : false,
@@ -128,7 +128,7 @@ export default class CurrencyInput extends React.Component
         onMouseOver  : undefined,
         placeholder  : undefined,
         textAlign    : 'left',
-        value        : '',
+        value        : undefined,
     };
 
 

--- a/src/CurrencyInput/tests.jsx
+++ b/src/CurrencyInput/tests.jsx
@@ -22,7 +22,7 @@ describe( 'CurrencyInput', () =>
 
     beforeEach( () =>
     {
-        wrapper  = shallow( <CurrencyInput /> );
+        wrapper  = shallow( <CurrencyInput value = "123" /> );
         instance = wrapper.instance();
     } );
 
@@ -227,7 +227,7 @@ describe( 'CurrencyInput', () =>
 
         describe( 'value', () =>
         {
-            test( 'should be empty string by default', () =>
+            test( 'should be an empty string by default', () =>
             {
                 expect( CurrencyInput.defaultProps.value ).toBe( '' );
             } );
@@ -243,7 +243,7 @@ describe( 'CurrencyInputDriver', () =>
 
     beforeEach( () =>
     {
-        wrapper = mount( <CurrencyInput /> );
+        wrapper = mount( <CurrencyInput value = "321" /> );
         driver  = wrapper.driver();
     } );
 
@@ -374,8 +374,8 @@ describe( 'CurrencyInputDriver', () =>
         {
             test( 'throws the expected error when isReadOnly', () =>
             {
-                const expectedError =
-                    'CurrencyInput cannot simulate change since it is read only';
+                const expectedError = 'CurrencyInput cannot simulate change \
+since it is read only';
                 wrapper.setProps( { isReadOnly: true } );
 
                 expect( () => driver.change() ).toThrow( expectedError );
@@ -456,8 +456,8 @@ describe( 'CurrencyInputDriver', () =>
         {
             test( 'throws the expected error when isDisabled', () =>
             {
-                const expectedError =
-                    'CurrencyInput cannot simulate keyPress since it is disabled';
+                const expectedError = 'CurrencyInput cannot simulate keyPress \
+since it is disabled';
                 wrapper.setProps( { isDisabled: true } );
 
                 expect( () => driver.keyPress() ).toThrow( expectedError );
@@ -497,8 +497,8 @@ describe( 'CurrencyInputDriver', () =>
         {
             test( 'throws the expected error when isDisabled', () =>
             {
-                const expectedError =
-                    'CurrencyInput cannot simulate keyDown since it is disabled';
+                const expectedError = 'CurrencyInput cannot simulate keyDown \
+since it is disabled';
                 wrapper.setProps( { isDisabled: true } );
 
                 expect( () => driver.keyDown() ).toThrow( expectedError );

--- a/src/PasswordInput/index.jsx
+++ b/src/PasswordInput/index.jsx
@@ -36,6 +36,10 @@ export default class PasswordInput extends React.Component
          */
         cssMap               : PropTypes.objectOf( PropTypes.string ),
         /**
+         *  Default input string value
+         */
+        defaultValue         : PropTypes.string,
+        /**
          *  Display as hover when required from another component
          */
         forceHover           : PropTypes.bool,
@@ -102,6 +106,7 @@ export default class PasswordInput extends React.Component
         aria                 : undefined,
         className            : undefined,
         cssMap               : undefined,
+        defaultValue         : undefined,
         forceHover           : false,
         hasError             : false,
         iconButtonIsDisabled : undefined,
@@ -116,7 +121,7 @@ export default class PasswordInput extends React.Component
         passwordIsVisible    : false,
         placeholder          : undefined,
         textAlign            : 'auto',
-        value                : '',
+        value                : undefined,
     };
 
     constructor( props )

--- a/src/TextArea/index.jsx
+++ b/src/TextArea/index.jsx
@@ -153,7 +153,7 @@ export default class TextArea extends React.Component
         autoCorrect    : undefined,
         className      : undefined,
         cssMap         : undefined,
-        defaultValue   : '',
+        defaultValue   : undefined,
         hasError       : false,
         id             : undefined,
         isDisabled     : false,
@@ -172,7 +172,7 @@ export default class TextArea extends React.Component
         rows           : 2,
         spellCheck     : undefined,
         textAlign      : 'left',
-        value          : '',
+        value          : undefined,
     };
 
     static displayName = 'TextArea';

--- a/src/TextArea/index.jsx
+++ b/src/TextArea/index.jsx
@@ -57,6 +57,10 @@ export default class TextArea extends React.Component
          */
         cssMap       : PropTypes.objectOf( PropTypes.string ),
         /**
+         *  Default input string value
+         */
+        defaultValue : PropTypes.string,
+        /**
          *  Display as error/invalid
          */
         hasError     : PropTypes.bool,
@@ -149,6 +153,7 @@ export default class TextArea extends React.Component
         autoCorrect    : undefined,
         className      : undefined,
         cssMap         : undefined,
+        defaultValue   : '',
         hasError       : false,
         id             : undefined,
         isDisabled     : false,
@@ -187,13 +192,14 @@ export default class TextArea extends React.Component
             autoComplete,
             autoCorrect,
             cssMap = createCssMap( this.context.TextArea, this.props ),
+            defaultValue,
             id = generateId( 'TextArea' ),
             isDisabled,
             isReadOnly,
             placeholder,
             rows,
             spellCheck,
-            value
+            value,
         } = this.props;
 
         return (
@@ -204,6 +210,7 @@ export default class TextArea extends React.Component
                 autoComplete   = { autoComplete }
                 autoCorrect    = { autoCorrect }
                 className      = { cssMap.main }
+                defaultValue   = { defaultValue }
                 disabled       = { isDisabled }
                 id             = { id }
                 placeholder    = { placeholder }

--- a/src/TextArea/tests.jsx
+++ b/src/TextArea/tests.jsx
@@ -119,9 +119,9 @@ describe( 'TextArea', () =>
 
         describe( 'value', () =>
         {
-            test( 'should be empty string by default', () =>
+            test( 'should be undefined by default', () =>
             {
-                expect( TextArea.defaultProps.value ).toBe( '' );
+                expect( TextArea.defaultProps.value ).toBe( undefined );
             } );
 
             test( 'should be passed to the input element', () =>

--- a/src/TextInput/index.jsx
+++ b/src/TextInput/index.jsx
@@ -57,6 +57,10 @@ export default class TextInput extends React.Component
          */
         cssMap       : PropTypes.objectOf( PropTypes.string ),
         /**
+         *  Default input string value
+         */
+        defaultValue : PropTypes.string,
+        /**
          *  Display as error/invalid
          */
         hasError     : PropTypes.bool,
@@ -134,6 +138,7 @@ export default class TextInput extends React.Component
         autoCorrect    : undefined,
         className      : undefined,
         cssMap         : undefined,
+        defaultValue   : undefined,
         hasError       : false,
         id             : undefined,
         isDisabled     : false,
@@ -170,6 +175,7 @@ export default class TextInput extends React.Component
             autoComplete,
             autoCorrect,
             cssMap = createCssMap( this.context.TextInput, this.props ),
+            defaultValue,
             id = generateId( 'TextInput' ),
             isDisabled,
             isReadOnly,
@@ -186,6 +192,7 @@ export default class TextInput extends React.Component
                 autoComplete   = { autoComplete }
                 autoCorrect    = { autoCorrect }
                 className      = { cssMap.main }
+                defaultValue   = { defaultValue }
                 disabled       = { isDisabled }
                 id             = { id }
                 placeholder    = { placeholder }

--- a/src/TextInput/index.jsx
+++ b/src/TextInput/index.jsx
@@ -155,7 +155,7 @@ export default class TextInput extends React.Component
         placeholder    : undefined,
         spellCheck     : undefined,
         textAlign      : 'left',
-        value          : '',
+        value          : undefined,
     };
 
     static displayName = 'TextInput';

--- a/src/TextInput/tests.jsx
+++ b/src/TextInput/tests.jsx
@@ -159,9 +159,9 @@ describe( 'TextInput', () =>
 
         describe( 'value', () =>
         {
-            test( 'should be empty string by default', () =>
+            test( 'should be undefined by default', () =>
             {
-                expect( TextInput.defaultProps.value ).toBe( '' );
+                expect( TextInput.defaultProps.value ).toBe( undefined );
             } );
             test( 'should be passed to the <input>', () =>
             {

--- a/src/TextInputWithIcon/index.jsx
+++ b/src/TextInputWithIcon/index.jsx
@@ -165,7 +165,7 @@ export default class TextInputWithIcon extends React.Component
         autoCorrect          : undefined,
         className            : undefined,
         cssMap               : undefined,
-        defaultValue         : '',
+        defaultValue         : undefined,
         forceHover           : false,
         hasError             : false,
         iconButtonIsDisabled : false,
@@ -188,7 +188,7 @@ export default class TextInputWithIcon extends React.Component
         placeholder          : undefined,
         spellCheck           : undefined,
         textAlign            : 'auto',
-        value                : '',
+        value                : undefined,
     };
 
     static displayName = 'TextInputWithIcon';

--- a/src/TextInputWithIcon/index.jsx
+++ b/src/TextInputWithIcon/index.jsx
@@ -60,6 +60,10 @@ export default class TextInputWithIcon extends React.Component
          */
         cssMap               : PropTypes.objectOf( PropTypes.string ),
         /**
+         *  Default input string value
+         */
+        defaultValue         : PropTypes.string,
+        /**
          *  Display as hover when required from another component
          */
         forceHover           : PropTypes.bool,
@@ -161,6 +165,7 @@ export default class TextInputWithIcon extends React.Component
         autoCorrect          : undefined,
         className            : undefined,
         cssMap               : undefined,
+        defaultValue         : '',
         forceHover           : false,
         hasError             : false,
         iconButtonIsDisabled : false,
@@ -196,6 +201,7 @@ export default class TextInputWithIcon extends React.Component
             autoComplete,
             autoCorrect,
             cssMap = createCssMap( this.context.TextInputWithIcon, this.props ),
+            defaultValue,
             forceHover,
             hasError,
             iconButtonIsDisabled,
@@ -232,6 +238,7 @@ export default class TextInputWithIcon extends React.Component
                     autoComplete   = { autoComplete }
                     autoCorrect    = { autoCorrect }
                     className      = { cssMap.input }
+                    defaultValue   = { defaultValue }
                     forceHover     = { forceHover }
                     hasError       = { hasError }
                     id             = { id }

--- a/src/TextInputWithIcon/index.jsx
+++ b/src/TextInputWithIcon/index.jsx
@@ -134,7 +134,7 @@ export default class TextInputWithIcon extends React.Component
         /**
          *  Mouse out callback function
          */
-        onMouseOut          : PropTypes.func,
+        onMouseOut           : PropTypes.func,
         /**
          *  Mouse over  callback function
          */

--- a/src/TextInputWithIcon/tests.jsx
+++ b/src/TextInputWithIcon/tests.jsx
@@ -227,9 +227,10 @@ describe( 'TextInputWithIcon', () =>
 
         describe( 'value', () =>
         {
-            test( 'should be empty string by default', () =>
+            test( 'should be undefined by default', () =>
             {
-                expect( TextInputWithIcon.defaultProps.value ).toBe( '' );
+                expect( TextInputWithIcon.defaultProps.value )
+                    .toBe( undefined );
             } );
 
             test( 'should be passed to the TextInput', () =>


### PR DESCRIPTION
For #866:

Returned support for uncontrolled inputs ( `defaultValue` / `isDefaultChecked` ) for:
- Checkbox
- CurrencyInput
- PasswordInput
- TextArea
- TextInput
- TextInputWithIcon