### PR TITLE
Issue 869 ComboBox multiselect with Tags

### DIFF
--- a/src/ComboBox/comboBox.css
+++ b/src/ComboBox/comboBox.css
@@ -33,7 +33,7 @@
     border-radius:      2px;
 
     padding-top:        3px;
-    padding-right:      3px;
+    padding-right:      var( --iconOffset );
     padding-bottom:     0;
     padding-left:       3px;
 
@@ -44,8 +44,8 @@
 
     & > *
     {
-        margin-right:   4px;
-        margin-bottom:  3px;
+        margin-right:   4px !important; /* always override default margins */
+        margin-bottom:  3px !important; /* always override default margins */
     }
 
     .input

--- a/src/ComboBox/comboBox.css
+++ b/src/ComboBox/comboBox.css
@@ -81,23 +81,23 @@
 
             &::placeholder
             {
-                color: transparent !important;
+                color:  transparent !important;
             }
         }
 
         &::placeholder
         {
             @extend %Nessie-RegularIt;
-            color:         var( --PC-GREY--L80 );
+            color:      var( --PC-GREY--L80 );
         }
     }
 
     .icon
     {
-        position:   absolute;
-        top:        50%;
-        right:      var( --iconOffset );
-        margin-top: calc( -1 * ( var( --iconSize ) / 2 ) );
+        position:       absolute;
+        top:            50%;
+        right:          var( --iconOffset );
+        margin-top:     calc( -1 * ( var( --iconSize ) / 2 ) );
     }
 
     &:focus-within
@@ -110,7 +110,7 @@
 
 .disabled
 {
-    pointer-events: none;
+    pointer-events:     none;
 
     &:hover
     {

--- a/src/ComboBox/comboBox.css
+++ b/src/ComboBox/comboBox.css
@@ -110,11 +110,17 @@
 
 .disabled
 {
-    pointer-events:     none;
+    pointer-events:         none;
+    background-color:       var( --PC-GREY--L90 );
 
     &:hover
     {
-        border-color:   ( --PC-GREY--L70 );
+        border-color:       var( --PC-GREY--L70 );
+    }
+
+    .input
+    {
+        background-color:   var( --PC-GREY--L90 );
     }
 }
 

--- a/src/ComboBox/comboBox.css
+++ b/src/ComboBox/comboBox.css
@@ -76,6 +76,7 @@
 
         &:focus
         {
+            @extend %Nessie-SemiBold;
             outline:    none;
 
             &::placeholder

--- a/src/ComboBox/comboBox.css
+++ b/src/ComboBox/comboBox.css
@@ -1,0 +1,125 @@
+/*
+ * Copyright (c) 2019 dunnhumby Germany GmbH.
+ * All rights reserved.
+ *
+ * This source code is licensed under the MIT license found in the LICENSE file
+ * in the root directory of this source tree.
+ *
+ */
+
+@import "../proto/base.css";
+
+:root
+{
+    --iconSize:     24px;
+    --borderWidth:  1px;
+
+    --iconOffset:   calc( var( --spacing-1 ) + var( --borderWidth ) );
+    --inputPadding: calc( var( --iconSize ) + ( 2 * var( --spacing-1 ) ) +
+        var( --borderWidth ) );
+}
+
+.default
+{
+    display:            flex;
+    flex-wrap:          wrap;
+    align-items:        flex-start;
+    align-content:      flex-start;
+
+    box-sizing:         border-box;
+    width:              100%;
+
+    border:             1px solid var( --PC-GREY--L70 );
+    border-radius:      2px;
+
+    padding-top:        3px;
+    padding-right:      3px;
+    padding-bottom:     0;
+    padding-left:       3px;
+
+    background-color:   var( --PC-WHITE );
+    outline:            none;
+
+    overflow-x:         hidden;
+
+    & > *
+    {
+        margin-right:   4px;
+        margin-bottom:  3px;
+    }
+
+    .input
+    {
+        flex:           1 0 0%;
+
+        box-sizing:     border-box;
+        min-width:      5ch;
+        min-height:     32px;
+
+        padding:        0;
+        padding-top:    1px;
+        padding-right:  var( --inputPadding );
+
+        border:         none;
+        margin-right:   0;
+
+        background:     transparent;
+
+        @extend         %Nessie-Regular;
+        font-size:      var( --typo-3 );
+        line-height:    var( --line-height-m );
+        letter-spacing: 0.4px;
+        text-indent:    5px;
+        color:          var( --PC-GREY--D5 );
+
+        resize:         none; /* required for Safari */
+
+        &:focus
+        {
+            outline:    none;
+
+            &::placeholder
+            {
+                color: transparent !important;
+            }
+        }
+
+        &::placeholder
+        {
+            @extend %Nessie-RegularIt;
+            color:         var( --PC-GREY--L80 );
+        }
+    }
+
+    .icon
+    {
+        position:   absolute;
+        top:        50%;
+        right:      var( --iconOffset );
+        margin-top: calc( -1 * ( var( --iconSize ) / 2 ) );
+    }
+
+    &:focus-within
+    {
+        border-color:   var( --PC-BLUE );
+        box-shadow:     0 0 0 2px color( var( --PC-BLUE ) a( 30% ) );
+    }
+}
+
+
+.disabled
+{
+    pointer-events: none;
+
+    &:hover
+    {
+        border-color:   ( --PC-GREY--L70 );
+    }
+}
+
+
+.error
+{
+    border-color:   var( --PC-RED ) !important; /* yes, always override other states */
+    box-shadow:     0 0 0 2px color( var( --PC-RED ) a( 30% ) );
+}

--- a/src/ComboBox/index.jsx
+++ b/src/ComboBox/index.jsx
@@ -209,9 +209,6 @@ export default class ComboBox extends Component
         value               : undefined,
     };
 
-    inputRef = React.createRef();
-    scrollBoxRef = React.createRef();
-
     constructor( { defaultValue, isMultiselect } )
     {
         super();
@@ -227,6 +224,9 @@ export default class ComboBox extends Component
             selection       : isMultiselect ?
                 castArray( defaultValue ) : defaultValue,
         };
+
+        this.inputRef     = React.createRef();
+        this.scrollBoxRef = React.createRef();
 
         this.handleBlur            = this.handleBlur.bind( this );
         this.handleChangeInput     = this.handleChangeInput.bind( this );
@@ -316,11 +316,11 @@ export default class ComboBox extends Component
         }
     }
 
-    focus()
+    filterOptions( tags )
     {
-        this.inputRef.current.focus();
+        return this.state.options.filter( option =>
+            !tags.includes( option.text ) );
     }
-
 
     handleChangeInput( { value }, ...args )
     {
@@ -335,7 +335,6 @@ export default class ComboBox extends Component
 
     handleClickIcon()
     {
-        // this.focus(); // focus() is broken
         this.setState( prevState => ( { isOpen: !prevState.isOpen } ) );
     }
 
@@ -387,17 +386,15 @@ export default class ComboBox extends Component
 
             return {
                 selection       : newTags,
-                // filteredOptions : this.filterOptions( newTags ),
+                filteredOptions : this.filterOptions( newTags ),
             };
         } );
     }
 
-    handleKeyDown( { key, preventNessieDefault } )
+    handleKeyDown( { key } )
     {
         if ( key === 'ArrowUp' || key === 'ArrowDown' )
         {
-            preventNessieDefault();
-
             this.setState( prevState =>
             {
                 const options = prevState.filteredOptions ||
@@ -489,6 +486,8 @@ export default class ComboBox extends Component
 
     handleBlur()
     {
+        this.handleClickIcon();
+
         this.setState( {
             activeOption    : undefined,
             isOpen          : false,
@@ -637,6 +636,7 @@ export default class ComboBox extends Component
                 <IconButton
                     className   = { cssMap.icon }
                     iconType    = { isOpen ? 'chevron-up' : 'chevron-down' }
+                    isFocusable = { false }
                     onClick     = { this.handleClickIcon } />
             </label>
         );

--- a/src/ComboBox/index.jsx
+++ b/src/ComboBox/index.jsx
@@ -338,12 +338,14 @@ export default class ComboBox extends Component
         }
     }
 
-    handleChangeInput( { value }, ...args )
+    handleChangeInput( e )
     {
+        const { value } = e.target;
+
         const { onChangeInput } = this.props;
         if ( typeof onChangeInput === 'function' )
         {
-            onChangeInput( { value }, ...args );
+            onChangeInput( value );
         }
 
         this.setState( { searchValue: value } );

--- a/src/ComboBox/index.jsx
+++ b/src/ComboBox/index.jsx
@@ -9,16 +9,21 @@
 
 /* global document */
 
-import React, { Component }                       from 'react';
-import PropTypes                                  from 'prop-types';
-import { castArray, escapeRegExp }                from 'lodash';
+import React, { Component }         from 'react';
+import PropTypes                    from 'prop-types';
+import { castArray, escapeRegExp }  from 'lodash';
 
-import { ListBox, ScrollBox, Text }               from '..';
+import {
+    IconButton,
+    ListBox,
+    ScrollBox,
+    Text,
+    TextInput,
+} from '..';
 
-import TextInputWithIcon                          from '../TextInputWithIcon';
 import Popup                                      from '../Popup';
 import PopperWrapper                              from '../PopperWrapper';
-import { callMultiple, generateId }               from '../utils';
+import { attachEvents, callMultiple, generateId } from '../utils';
 import { addPrefix, prefixOptions, removePrefix } from './utils';
 import { buildTagsFromValues }                    from '../TagInput/utils';
 
@@ -462,12 +467,7 @@ export default class ComboBox extends Component
         } = this.state;
 
         const selectedOption = getOption( selection, flatOptions );
-        let selectedText = selectedOption ? selectedOption.text : '';
-
-        if ( isMultiselect )
-        {
-            selectedText = buildTagsFromValues( selection );
-        }
+        const selectedText = selectedOption ? selectedOption.text : '';
 
         let optionsToShow = options || [];
 
@@ -521,46 +521,50 @@ export default class ComboBox extends Component
         }
 
         const popperChildren = (
-            <TextInputWithIcon
-                aria = { {
-                    activeDescendant :
-                        activeOption && addPrefix( activeOption, id ),
-                    autocomplete : 'list',
-                    expanded     : isOpen,
-                    hasPopup     : 'listbox',
-                    owns         : addPrefix( 'listbox', id ),
-                    role         : 'combobox',
-                } }
-                autoCapitalize = "off"
-                autoComplete   = "off"
-                autoCorrect    = "off"
-                className      = { className }
-                hasError       = { hasError }
-                iconType       = { isOpen ? 'chevron-up' : 'chevron-down' }
-                id             = { id }
-                inputRef       = { this.inputRef }
-                isDisabled     = { isDisabled }
-                isReadOnly     = { !isSearchable || !isOpen }
-                onBlur         = { callMultiple(
-                    this.handleBlur,
-                    this.props.onBlur,
-                ) } // temporary fix
-                onChangeInput  = { this.handleChangeInput }
-                onClick        = { callMultiple(
-                    this.handleClick,
-                    this.props.onClick,
-                ) } // temporary fix
-                onClickIcon    = { this.handleClickIcon }
-                onFocus        = { this.props.onFocus } // temporary fix
-                onKeyDown      = { callMultiple(
-                    this.handleKeyDown,
-                    this.props.onKeyDown,
-                ) } // temporary fix
-                placeholder    = { inputPlaceholder }
-                spellCheck     = { false }
-                value          = { ( isOpen && isSearchable ) ?
-                    searchValue : selectedText
-                } />
+            <div { ...attachEvents( this.props ) }>
+                { isMultiselect && buildTagsFromValues( selection ) }
+                <TextInput
+                    aria = { {
+                        activeDescendant :
+                            activeOption && addPrefix( activeOption, id ),
+                        autocomplete : 'list',
+                        expanded     : isOpen,
+                        hasPopup     : 'listbox',
+                        owns         : addPrefix( 'listbox', id ),
+                        role         : 'combobox',
+                    } }
+                    autoCapitalize = "off"
+                    autoComplete   = "off"
+                    autoCorrect    = "off"
+                    className      = { className }
+                    hasError       = { hasError }
+                    id             = { id }
+                    inputRef       = { this.inputRef }
+                    isDisabled     = { isDisabled }
+                    isReadOnly     = { !isSearchable || !isOpen }
+                    onBlur         = { callMultiple(
+                        this.handleBlur,
+                        this.props.onBlur,
+                    ) } // temporary fix
+                    onChangeInput  = { this.handleChangeInput }
+                    onClick        = { callMultiple(
+                        this.handleClick,
+                        this.props.onClick,
+                    ) } // temporary fix
+                    onFocus        = { this.props.onFocus } // temporary fix
+                    onKeyDown      = { callMultiple(
+                        this.handleKeyDown,
+                        this.props.onKeyDown,
+                    ) } // temporary fix
+                    placeholder    = { inputPlaceholder }
+                    spellCheck     = { false }
+                    value          = { ( isOpen && isSearchable ) ?
+                        searchValue : selectedText } />
+                <IconButton
+                    className   = { className }
+                    iconType    = { isOpen ? 'chevron-up' : 'chevron-down' }
+                    onClickIcon = { this.handleClickIcon } />
+            </div>
         );
 
         const popperPopup = (

--- a/src/ComboBox/index.jsx
+++ b/src/ComboBox/index.jsx
@@ -20,6 +20,7 @@ import Popup                                      from '../Popup';
 import PopperWrapper                              from '../PopperWrapper';
 import { callMultiple, generateId }               from '../utils';
 import { addPrefix, prefixOptions, removePrefix } from './utils';
+import { buildTagsFromValues }                    from '../TagInput/utils';
 
 /**
  * gets the index of the option by the passed id
@@ -156,7 +157,7 @@ export default class ComboBox extends Component
     {
         className           : undefined,
         container           : undefined,
-        defaultValue        : undefined,
+        defaultValue        : [],
         dropdownPlaceholder : 'No results to show',
         hasError            : false,
         id                  : undefined,
@@ -460,21 +461,12 @@ export default class ComboBox extends Component
             selection,
         } = this.state;
 
-        let selectedOption = getOption( selection, flatOptions );
+        const selectedOption = getOption( selection, flatOptions );
         let selectedText = selectedOption ? selectedOption.text : '';
 
         if ( isMultiselect )
         {
-            if ( selection.length === 1 )
-            {
-                selectedOption = getOption( selection[ 0 ], flatOptions );
-                selectedText = selectedOption ? selectedOption.text : '';
-            }
-            else if ( selection.length > 1 )
-            {
-                selectedText =
-                    selection.length && `(${selection.length} items selected)`;
-            }
+            selectedText = buildTagsFromValues( selection );
         }
 
         let optionsToShow = options || [];

--- a/src/ComboBox/index.jsx
+++ b/src/ComboBox/index.jsx
@@ -172,6 +172,10 @@ export default class ComboBox extends Component
          *  Change callback: ( { value } ) => ...
          */
         onChange            : PropTypes.func,
+        /**
+         *  Input field change callback: ( { value } ) => ...
+         */
+        onChangeInput       : PropTypes.func,
         /*
          * Dropdown list options
          */
@@ -200,6 +204,7 @@ export default class ComboBox extends Component
         isReadOnly          : undefined,
         isSearchable        : false,
         onChange            : undefined,
+        onChangeInput       : undefined,
         options             : undefined,
         value               : undefined,
     };
@@ -333,13 +338,12 @@ export default class ComboBox extends Component
         }
     }
 
-    handleChangeInput( e, ...args )
+    handleChangeInput( { value }, ...args )
     {
-        const { value } = e.target;
-        const { onChange } = this.props;
-        if ( typeof onChange === 'function' )
+        const { onChangeInput } = this.props;
+        if ( typeof onChangeInput === 'function' )
         {
-            onChange( { value }, ...args );
+            onChangeInput( { value }, ...args );
         }
 
         this.setState( { searchValue: value } );

--- a/src/ComboBox/index.jsx
+++ b/src/ComboBox/index.jsx
@@ -311,6 +311,11 @@ export default class ComboBox extends Component
         }
     }
 
+    focus()
+    {
+        this.inputRef.current.focus();
+    }
+
     filterOptions( tags )
     {
         return this.state.options.filter( option =>
@@ -331,6 +336,7 @@ export default class ComboBox extends Component
 
     handleClickIcon()
     {
+        this.focus();
         this.setState( prevState => ( { isOpen: !prevState.isOpen } ) );
     }
 
@@ -483,8 +489,6 @@ export default class ComboBox extends Component
 
     handleBlur()
     {
-        this.handleClickIcon();
-
         this.setState( {
             activeOption    : undefined,
             isOpen          : false,

--- a/src/ComboBox/index.jsx
+++ b/src/ComboBox/index.jsx
@@ -399,7 +399,7 @@ export default class ComboBox extends Component
             const { onChangeValue } = this.props;
             if ( typeof onChangeValue === 'function' )
             {
-                onChangeValue( { selection: newTags } );
+                onChangeValue( { value: newTags } );
             }
 
             return {

--- a/src/ComboBox/index.jsx
+++ b/src/ComboBox/index.jsx
@@ -172,10 +172,6 @@ export default class ComboBox extends Component
          *  Change callback: ( { value } ) => ...
          */
         onChange            : PropTypes.func,
-        /**
-         *  Input field change callback: ( { value } ) => ...
-         */
-        onChangeInput       : PropTypes.func,
         /*
          * Dropdown list options
          */
@@ -204,7 +200,6 @@ export default class ComboBox extends Component
         isReadOnly          : undefined,
         isSearchable        : false,
         onChange            : undefined,
-        onChangeInput       : undefined,
         options             : undefined,
         value               : undefined,
     };
@@ -322,12 +317,13 @@ export default class ComboBox extends Component
             !tags.includes( option.text ) );
     }
 
-    handleChangeInput( { value }, ...args )
+    handleChangeInput( e, ...args )
     {
-        const { onChangeInput } = this.props;
-        if ( typeof onChangeInput === 'function' )
+        const { value } = e.target;
+        const { onChange } = this.props;
+        if ( typeof onChange === 'function' )
         {
-            onChangeInput( { value }, ...args );
+            onChange( { value }, ...args );
         }
 
         this.setState( { searchValue: value } );
@@ -619,7 +615,8 @@ export default class ComboBox extends Component
                         this.handleBlur,
                         this.props.onBlur,
                     ) } // temporary fix
-                    onChangeInput  = { this.handleChangeInput }
+                    onChange       = { isSearchable ?
+                        this.handleChangeInput : null }
                     onClick        = { callMultiple(
                         this.handleClick,
                         this.props.onClick,

--- a/src/ComboBox/index.jsx
+++ b/src/ComboBox/index.jsx
@@ -18,14 +18,23 @@ import {
     ListBox,
     ScrollBox,
     Text,
-    TextInput,
 } from '..';
 
-import Popup                                      from '../Popup';
-import PopperWrapper                              from '../PopperWrapper';
-import { attachEvents, callMultiple, generateId } from '../utils';
-import { addPrefix, prefixOptions, removePrefix } from './utils';
-import { buildTagsFromValues }                    from '../TagInput/utils';
+import Popup            from '../Popup';
+import PopperWrapper    from '../PopperWrapper';
+import {
+    attachEvents,
+    callMultiple,
+    generateId,
+} from '../utils';
+import {
+    addPrefix,
+    prefixOptions,
+    removePrefix,
+} from './utils';
+import { buildTagsFromValues }  from '../TagInput/utils';
+import ThemeContext             from '../Theming/ThemeContext';
+import { createCssMap }         from '../Theming';
 
 /**
  * normalize array of options or value
@@ -103,6 +112,8 @@ function optionsFormatted( filteredOptionsIds, originalOptions )
 
 export default class ComboBox extends Component
 {
+    static contextType = ThemeContext;
+
     static propTypes =
     {
         /**
@@ -120,6 +131,10 @@ export default class ComboBox extends Component
          *  id of the DOM element used as container for popup listBox
          */
         container           : PropTypes.string,
+        /**
+         *  CSS class map
+         */
+        cssMap              : PropTypes.objectOf( PropTypes.string ),
         /**
          * Placeholder text to show when no dropdown list options
          */
@@ -177,6 +192,7 @@ export default class ComboBox extends Component
     {
         className           : undefined,
         container           : undefined,
+        cssMap              : undefined,
         defaultValue        : [],
         dropdownPlaceholder : 'No results to show',
         hasError            : false,
@@ -465,6 +481,7 @@ export default class ComboBox extends Component
         const {
             className,
             container,
+            cssMap = createCssMap( this.context.ComboBox, this.props ),
             dropdownPlaceholder,
             hasError,
             inputPlaceholder,
@@ -540,9 +557,12 @@ export default class ComboBox extends Component
         }
 
         const popperChildren = (
-            <div { ...attachEvents( this.props ) }>
+            <label
+                { ...attachEvents( this.props ) }
+                className = { cssMap.main }
+                htmlFor   = { id }>
                 { isMultiselect && buildTagsFromValues( selection ) }
-                <TextInput
+                <input
                     aria = { {
                         activeDescendant :
                             activeOption && addPrefix( activeOption, id ),
@@ -555,7 +575,7 @@ export default class ComboBox extends Component
                     autoCapitalize = "off"
                     autoComplete   = "off"
                     autoCorrect    = "off"
-                    className      = { className }
+                    className      = { cssMap.input }
                     hasError       = { hasError }
                     id             = { id }
                     inputRef       = { this.inputRef }
@@ -580,10 +600,10 @@ export default class ComboBox extends Component
                     value          = { ( isOpen && isSearchable ) ?
                         searchValue : selectedText } />
                 <IconButton
-                    className   = { className }
+                    className   = { cssMap.icon }
                     iconType    = { isOpen ? 'chevron-up' : 'chevron-down' }
                     onClickIcon = { this.handleClickIcon } />
-            </div>
+            </label>
         );
 
         const popperPopup = (

--- a/src/ComboBox/index.jsx
+++ b/src/ComboBox/index.jsx
@@ -345,7 +345,7 @@ export default class ComboBox extends Component
         const { onChangeInput } = this.props;
         if ( typeof onChangeInput === 'function' )
         {
-            onChangeInput( value );
+            onChangeInput( { value } );
         }
 
         this.setState( { searchValue: value } );

--- a/src/ComboBox/index.jsx
+++ b/src/ComboBox/index.jsx
@@ -171,7 +171,7 @@ export default class ComboBox extends Component
         /**
          *  Change callback: ( { value } ) => ...
          */
-        onChange            : PropTypes.func,
+        onChangeValue       : PropTypes.func,
         /**
          *  Input field change callback: ( { value } ) => ...
          */
@@ -203,7 +203,7 @@ export default class ComboBox extends Component
         isMultiselect       : false,
         isReadOnly          : undefined,
         isSearchable        : false,
-        onChange            : undefined,
+        onChangeValue       : undefined,
         onChangeInput       : undefined,
         options             : undefined,
         value               : undefined,
@@ -365,7 +365,7 @@ export default class ComboBox extends Component
         this.setState( ( { id, selection } ) =>
         {
             const optId = removePrefix( prefixedId, id );
-            const { isMultiselect, onChange } = this.props;
+            const { isMultiselect, onChangeValue } = this.props;
 
             let newSelection = optId;
             if ( isMultiselect )
@@ -375,9 +375,9 @@ export default class ComboBox extends Component
                     [ ...selection, optId ];
             }
 
-            if ( typeof onChange === 'function' )
+            if ( typeof onChangeValue === 'function' )
             {
-                onChange( { value: newSelection } );
+                onChangeValue( { value: newSelection } );
             }
 
             return {
@@ -396,10 +396,10 @@ export default class ComboBox extends Component
         {
             const newTags = selection.filter( tag => tag !== id );
 
-            const { onChange } = this.props;
-            if ( typeof onChange === 'function' )
+            const { onChangeValue } = this.props;
+            if ( typeof onChangeValue === 'function' )
             {
-                onChange( { selection: newTags } );
+                onChangeValue( { selection: newTags } );
             }
 
             return {
@@ -468,10 +468,10 @@ export default class ComboBox extends Component
                     }
                     newSelection = newSelection || selection;
 
-                    const { onChange } = this.props;
-                    if ( typeof onChange === 'function' )
+                    const { onChangeValue } = this.props;
+                    if ( typeof onChangeValue === 'function' )
                     {
-                        onChange( { value: newSelection } );
+                        onChangeValue( { value: newSelection } );
                     }
 
                     return {
@@ -637,8 +637,7 @@ export default class ComboBox extends Component
                         this.handleBlur,
                         this.props.onBlur,
                     ) } // temporary fix
-                    onChange       = { isSearchable ?
-                        this.handleChangeInput : null }
+                    onChange       = { this.handleChangeInput }
                     onClick        = { callMultiple(
                         this.handleClick,
                         this.props.onClick,

--- a/src/ComboBox/index.jsx
+++ b/src/ComboBox/index.jsx
@@ -394,10 +394,14 @@ export default class ComboBox extends Component
         } );
     }
 
-    handleKeyDown( { key } )
+    handleKeyDown( e )
     {
+        const { key } = e;
+
         if ( key === 'ArrowUp' || key === 'ArrowDown' )
         {
+            e.preventDefault();
+
             this.setState( prevState =>
             {
                 const options = prevState.filteredOptions ||

--- a/src/ComboBox/index.jsx
+++ b/src/ComboBox/index.jsx
@@ -229,6 +229,7 @@ export default class ComboBox extends Component
         this.handleClickClose      = this.handleClickClose.bind( this );
         this.handleClickIcon       = this.handleClickIcon.bind( this );
         this.handleClickOption     = this.handleClickOption.bind( this );
+        this.handleFocus           = this.handleFocus.bind( this );
         this.handleKeyDown         = this.handleKeyDown.bind( this );
         this.handleMouseOutOption  = this.handleMouseOutOption.bind( this );
         this.handleMouseOverOption = this.handleMouseOverOption.bind( this );
@@ -320,6 +321,16 @@ export default class ComboBox extends Component
     {
         return this.state.options.filter( option =>
             !tags.includes( option.text ) );
+    }
+
+    handleFocus()
+    {
+        this.focus();
+
+        if ( this.props.isSearchable )
+        {
+            this.setState( { searchValue: '' } );
+        }
     }
 
     handleChangeInput( e, ...args )
@@ -628,7 +639,10 @@ export default class ComboBox extends Component
                         this.handleClick,
                         this.props.onClick,
                     ) } // temporary fix
-                    onFocus        = { this.props.onFocus } // temporary fix
+                    onFocus        = { callMultiple(
+                        this.handleFocus,
+                        this.props.onFocus,
+                    ) } // temporary fix
                     onKeyDown      = { callMultiple(
                         this.handleKeyDown,
                         this.props.onKeyDown,

--- a/src/ComboBox/index.jsx
+++ b/src/ComboBox/index.jsx
@@ -345,6 +345,7 @@ export default class ComboBox extends Component
         {
             const optId = removePrefix( prefixedId, id );
             const { isMultiselect, onChange } = this.props;
+
             let newSelection = optId;
             if ( isMultiselect )
             {
@@ -606,11 +607,9 @@ export default class ComboBox extends Component
                     autoComplete   = "off"
                     autoCorrect    = "off"
                     className      = { cssMap.input }
+                    disabled       = { isDisabled }
                     hasError       = { hasError }
                     id             = { id }
-                    inputRef       = { this.inputRef }
-                    isDisabled     = { isDisabled }
-                    isReadOnly     = { !isSearchable || !isOpen }
                     onBlur         = { callMultiple(
                         this.handleBlur,
                         this.props.onBlur,
@@ -627,6 +626,8 @@ export default class ComboBox extends Component
                         this.props.onKeyDown,
                     ) } // temporary fix
                     placeholder    = { inputPlaceholder }
+                    readOnly       = { !isSearchable || !isOpen }
+                    ref            = { this.inputRef }
                     spellCheck     = { false }
                     value          = { ( isOpen && isSearchable ) ?
                         searchValue : selectedText } />

--- a/src/DefaultTheme.js
+++ b/src/DefaultTheme.js
@@ -81,10 +81,13 @@ export default {
         ),
         ...checkboxClasses,
     } ),
-    ComboBox : {
-        main : classNames.bind( comboBoxClasses )( 'default' ),
+    ComboBox : props => ( {
+        main : classNames.bind( comboBoxClasses )(
+            'default',
+            props.className,
+        ),
         ...comboBoxClasses,
-    },
+    } ),
     DatePicker : {
         main : classNames.bind( datePickerClasses )( 'default' ),
         ...datePickerClasses,

--- a/src/DefaultTheme.js
+++ b/src/DefaultTheme.js
@@ -84,6 +84,9 @@ export default {
     ComboBox : props => ( {
         main : classNames.bind( comboBoxClasses )(
             'default',
+            {
+                disabled : props.isDisabled,
+            },
             props.className,
         ),
         ...comboBoxClasses,

--- a/src/DefaultTheme.js
+++ b/src/DefaultTheme.js
@@ -85,7 +85,7 @@ export default {
         main : classNames.bind( comboBoxClasses )(
             'default',
             {
-                disabled : props.isDisabled,
+                disabled : !props.isMultiselect && props.isDisabled,
             },
             props.className,
         ),

--- a/src/DefaultTheme.js
+++ b/src/DefaultTheme.js
@@ -86,6 +86,7 @@ export default {
             'default',
             {
                 disabled : !props.isMultiselect && props.isDisabled,
+                error    : props.hasError,
             },
             props.className,
         ),

--- a/src/DefaultTheme.js
+++ b/src/DefaultTheme.js
@@ -12,6 +12,7 @@ import classNames                from 'classnames/bind';
 import buttonClasses             from './Button/button.css';
 import cardClasses               from './Card/card.css';
 import checkboxClasses           from './Checkbox/checkbox.css';
+import comboBoxClasses           from './ComboBox/comboBox.css';
 import datePickerClasses         from './DatePicker/datePicker.css';
 import datePickerHeaderClasses   from './DatePicker/datePickerHeader.css';
 import datePickerItemClasses     from './DatePicker/datePickerItem.css';
@@ -80,6 +81,10 @@ export default {
         ),
         ...checkboxClasses,
     } ),
+    ComboBox : {
+        main : classNames.bind( comboBoxClasses )( 'default' ),
+        ...comboBoxClasses,
+    },
     DatePicker : {
         main : classNames.bind( datePickerClasses )( 'default' ),
         ...datePickerClasses,

--- a/src/TagInput/tagInput.css
+++ b/src/TagInput/tagInput.css
@@ -94,7 +94,7 @@
 
     &:hover
     {
-        border-color:   ( --PC-GREY--L70 );
+        border-color:   var( --PC-GREY--L70 );
     }
 }
 


### PR DESCRIPTION
For #869:

In order to display selected options as `Tag` when `isMultiselect`, we did few changes:

- `ComboBox` now consists of `label` that wraps `Tag`, `input` and `IconButton` (basically, how `TagInput` is built)
- added functionality that displays and controls `Tag` components when `isMultiselect`
- added styles for `ComboBox` that combines the previous look + supports displaying `Tag`; because of the way ComboBox is (re)built, we can't achieve this by using existing components

- fixed minor bug: when `isMultiselect` while `defaultValue: undefined`, it would create an array that always had `null` as a first item in that array; this was always causing the total number of selected options to be +1. Therefore, default value is set to `defaultValue: []`.
