### PR TITLE
Issue 913 PasswordInput bug

### DIFF
--- a/src/PasswordInput/index.jsx
+++ b/src/PasswordInput/index.jsx
@@ -11,24 +11,18 @@ import React, {
     useState,
     useCallback,
     forwardRef,
-}  from 'react';
-import PropTypes             from 'prop-types';
+}                               from 'react';
+import PropTypes                from 'prop-types';
 
-import { TextInputWithIcon } from '..';
+import { TextInputWithIcon }    from '..';
 
-import { generateId }        from '../utils';
 
 const componentName = 'PasswordInput';
-
 
 const PasswordInput = forwardRef( ( props, ref ) =>
 {
     const [ passwordIsVisibleState,
         setPasswordIsVisibleState ] = useState( false );
-
-    const {
-        id = generateId( componentName ),
-    } = props;
 
     const passwordIsVisible =
         props.passwordIsVisible || passwordIsVisibleState;
@@ -42,7 +36,6 @@ const PasswordInput = forwardRef( ( props, ref ) =>
         {
             onClickIcon(
                 {
-                    id,
                     preventNessieDefault()
                     {
                         nessieDefaultPrevented = true;
@@ -56,7 +49,7 @@ const PasswordInput = forwardRef( ( props, ref ) =>
         {
             setPasswordIsVisibleState( !passwordIsVisibleState );
         }
-    }, [ id, onClickIcon, passwordIsVisibleState ] );
+    }, [ onClickIcon, passwordIsVisibleState ] );
 
     return (
         <TextInputWithIcon
@@ -65,7 +58,6 @@ const PasswordInput = forwardRef( ( props, ref ) =>
             autoComplete   = "off"
             autoCorrect    = "off"
             iconType       = { passwordIsVisible ? 'eye-off' : 'eye' }
-            id             = { id }
             inputType      = { passwordIsVisible ? 'text' : 'password' }
             onClickIcon    = { handleClickIcon }
             ref            = { ref }
@@ -113,10 +105,6 @@ PasswordInput.propTypes =
      *  Alignment of the icon
      */
     iconPosition         : PropTypes.oneOf( [ 'left', 'right' ] ),
-    /**
-     *  Component id
-     */
-    id                   : PropTypes.string,
     /**
      *  Callback that receives the native <input>: ( ref ) => { ... }
      */
@@ -169,7 +157,6 @@ PasswordInput.defaultProps =
     hasError             : false,
     iconButtonIsDisabled : undefined,
     iconPosition         : 'right',
-    id                   : undefined,
     inputRef             : undefined,
     isDisabled           : false,
     isReadOnly           : false,
@@ -179,7 +166,7 @@ PasswordInput.defaultProps =
     passwordIsVisible    : false,
     placeholder          : undefined,
     textAlign            : 'auto',
-    value                : '',
+    value                : undefined,
 };
 
 export default PasswordInput;

--- a/src/TextArea/index.jsx
+++ b/src/TextArea/index.jsx
@@ -215,7 +215,7 @@ TextArea.defaultProps =
     rows           : 2,
     spellCheck     : undefined,
     textAlign      : 'left',
-    value          : '',
+    value          : undefined,
 };
 
 TextArea.displayName = componentName;

--- a/src/TextInput/index.jsx
+++ b/src/TextInput/index.jsx
@@ -39,6 +39,7 @@ const TextInput = forwardRef( ( props, ref ) =>
         isReadOnly,
         placeholder,
         spellCheck,
+        type,
         value,
     } = props;
 
@@ -57,6 +58,7 @@ const TextInput = forwardRef( ( props, ref ) =>
             readOnly       = { isReadOnly }
             ref            = { inputRef }
             spellCheck     = { spellCheck }
+            type           = { type }
             value          = { value } />
     );
 } );
@@ -167,6 +169,10 @@ TextInput.propTypes =
      */
     textAlign    : PropTypes.oneOf( [ 'left', 'right' ] ),
     /**
+     *  HTML type attribute (input element only)
+     */
+    type         : PropTypes.oneOf( [ 'text', 'password' ] ),
+    /**
      *  Input string value
      */
     value        : PropTypes.string,
@@ -197,7 +203,8 @@ TextInput.defaultProps =
     placeholder    : undefined,
     spellCheck     : undefined,
     textAlign      : 'left',
-    value          : '',
+    type           : 'text',
+    value          : undefined,
 };
 
 TextInput.displayName = componentName;

--- a/src/TextInputWithIcon/index.jsx
+++ b/src/TextInputWithIcon/index.jsx
@@ -258,7 +258,7 @@ TextInputWithIcon.defaultProps =
     placeholder          : undefined,
     spellCheck           : undefined,
     textAlign            : 'auto',
-    value                : '',
+    value                : undefined,
 };
 
 TextInputWithIcon.displayName = componentName;


### PR DESCRIPTION
For #913:

- set default `value` as `undefined` to `TextInput`, `TextInputWithIcon` and `PasswordInput`
- removed `id` from `PasswordInput`
- added prop `type` to `TextInput`