### PR TITLE
Returned id prop that was removed from components #804

### DIFF
--- a/src/Button/index.jsx
+++ b/src/Button/index.jsx
@@ -32,6 +32,7 @@ const Button = forwardRef( ( props, ref ) =>
     const {
         children,
         iconType,
+        id,
         isDisabled,
         isLoading,
         label,
@@ -44,6 +45,7 @@ const Button = forwardRef( ( props, ref ) =>
             { ...attachEvents( props ) }
             className = { cssMap.main }
             disabled  = { isDisabled }
+            id        = { id }
             ref       = { buttonRef }
             type      = "button">
             <div className = { cssMap.content }>
@@ -89,6 +91,10 @@ Button.propTypes =
      */
     iconType     : PropTypes.string,
     /**
+     * Component identifier
+     */
+    id           : PropTypes.string,
+    /**
      *  Display as disabled
      */
     isDisabled   : PropTypes.bool,
@@ -131,6 +137,7 @@ Button.defaultProps =
     cssMap       : undefined,
     iconPosition : 'left',
     iconType     : 'none',
+    id           : undefined,
     isDisabled   : false,
     isLoading    : false,
     label        : undefined,

--- a/src/CurrencyInput/index.jsx
+++ b/src/CurrencyInput/index.jsx
@@ -28,8 +28,9 @@ const CurrencyInput = ( props ) =>
 {
     const {
         currency,
-        value,
         defaultValue,
+        id,
+        value,
         ...restProps
     } = props;
 
@@ -63,6 +64,7 @@ const CurrencyInput = ( props ) =>
             autoCapitalize = "off"
             autoComplete   = "off"
             autoCorrect    = "off"
+            id             = { id }
             spellCheck     = { false }
             onBlur         = { handleBlur }
             onChange       = { handleChange }
@@ -93,6 +95,10 @@ CurrencyInput.propTypes =
      *  Display as error/invalid
      */
     hasError     : PropTypes.bool,
+    /**
+     *  HTML id attribute
+     */
+    id           : PropTypes.string,
     /**
      *  Display as disabled
      */
@@ -158,6 +164,7 @@ CurrencyInput.defaultProps =
     currency     : undefined,
     defaultValue : '',
     hasError     : false,
+    id           : undefined,
     isDisabled   : false,
     isReadOnly   : false,
     onBlur       : undefined,

--- a/src/DatePicker/TimeInput.jsx
+++ b/src/DatePicker/TimeInput.jsx
@@ -27,6 +27,7 @@ const TimeInput = props =>
         hourIsReadOnly,
         hourPlaceholder,
         hourValue,
+        id,
         isDisabled,
         isReadOnly,
         minuteIsDisabled,
@@ -42,6 +43,7 @@ const TimeInput = props =>
             <input
                 className   = { cssMap.hour }
                 disabled    = { isDisabled || hourIsDisabled }
+                id          = { `${id}-hour` }
                 onChange    = { createEventHandler( onChangeHour ) }
                 placeholder = { hourPlaceholder }
                 readOnly    = { isReadOnly || hourIsReadOnly }
@@ -51,6 +53,7 @@ const TimeInput = props =>
             <input
                 className   = { cssMap.min }
                 disabled    = { isDisabled || minuteIsDisabled }
+                id          = { `${id}-minute` }
                 onChange    = { createEventHandler( onChangeMinute ) }
                 placeholder = { minutePlaceholder }
                 readOnly    = { isReadOnly || minuteIsReadOnly }
@@ -68,6 +71,7 @@ TimeInput.propTypes =
     hourIsReadOnly    : PropTypes.bool,
     hourPlaceholder   : PropTypes.string,
     hourValue         : PropTypes.string,
+    id                : PropTypes.string,
     isDisabled        : PropTypes.bool,
     isReadOnly        : PropTypes.bool,
     minuteIsDisabled  : PropTypes.bool,
@@ -86,6 +90,7 @@ TimeInput.defaultProps =
     hourIsReadOnly    : false,
     hourPlaceholder   : 'HH',
     hourValue         : undefined,
+    id                : undefined,
     isDisabled        : false,
     isReadOnly        : false,
     minuteIsDisabled  : false,

--- a/src/DateTimeInput/index.jsx
+++ b/src/DateTimeInput/index.jsx
@@ -206,12 +206,12 @@ const DateTimeInput = React.forwardRef( ( props, ref ) =>
 
             if ( typeof onChange === 'function' )
             {
-                onChange( { value } );
+                onChange( { id, value } );
             }
         }
 
         purgeEdits();
-    }, [ props.isReadOnly, props.onChange, timestamp ] );
+    }, [ props.id, props.isReadOnly, props.onChange, timestamp ] );
 
 
     const handleClickNext = useCallback( () =>
@@ -505,6 +505,7 @@ const DateTimeInput = React.forwardRef( ( props, ref ) =>
         format,
         hasError,
         hourPlaceholder,
+        id,
         inputPlaceholder,
         isDisabled,
         minutePlaceholder,
@@ -551,6 +552,7 @@ const DateTimeInput = React.forwardRef( ( props, ref ) =>
             forceHover     = { isOpen }
             hasError       = { hasError }
             iconType       = "calendar"
+            id             = { id }
             inputRef       = { inputRef }
             isDisabled     = { isDisabled }
             onChangeInput  = { handleChangeInput }
@@ -605,6 +607,10 @@ DateTimeInput.propTypes =
      */
     hourPlaceholder   : PropTypes.string,
     /**
+     *  Component id
+     */
+    id                : PropTypes.string,
+    /**
      *  Main input placeholder text
      */
     inputPlaceholder  : PropTypes.string,
@@ -649,6 +655,7 @@ DateTimeInput.defaultProps =
     format            : undefined,
     hasError          : false,
     hourPlaceholder   : undefined,
+    id                : undefined,
     inputPlaceholder  : undefined,
     isDisabled        : false,
     isReadOnly        : false,

--- a/src/IconButton/index.jsx
+++ b/src/IconButton/index.jsx
@@ -26,6 +26,7 @@ const IconButton = props =>
         children,
         iconSize,
         iconType,
+        id,
         isDisabled,
         isFocusable,
         label,
@@ -41,6 +42,7 @@ const IconButton = props =>
             } ) }
             className   = { cssMap.main }
             disabled    = { isDisabled }
+            id          = { id }
             onMouseDown = { !isFocusable ? killFocus : undefined }
             ref         = { buttonRef }
             tabIndex    = { isFocusable ? '0' : '-1' }
@@ -92,6 +94,10 @@ IconButton.propTypes =
      */
     iconType      : PropTypes.string,
     /**
+     * Component id
+     */
+    id            : PropTypes.string,
+    /**
      *  Display as disabled
      */
     isDisabled    : PropTypes.bool,
@@ -127,6 +133,7 @@ IconButton.defaultProps =
     hasBackground : false,
     iconSize      : 'S',
     iconType      : undefined,
+    id            : undefined,
     isDisabled    : false,
     isFocusable   : true,
     label         : undefined,

--- a/src/ListBox/index.jsx
+++ b/src/ListBox/index.jsx
@@ -30,6 +30,7 @@ const ListBox = props =>
         aria,
         activeOption,
         children,
+        id,
         isFocusable,
         isMultiselect,
         onClickOption,
@@ -57,6 +58,7 @@ const ListBox = props =>
                 role             : 'listbox',
             } ) }
             className   = { cssMap.main }
+            id          = { id }
             onMouseDown = { !isFocusable ? killFocus : undefined }
             tabIndex    = { isFocusable ? '0' : '-1' }>
             { updateOptions(
@@ -91,6 +93,10 @@ ListBox.propTypes = {
     isFocusable       : PropTypes.bool,
     isMultiselect     : PropTypes.bool,
     /**
+    *  ListBox ID
+    */
+    id                : PropTypes.string,
+    /**
     *  Array of strings or objects (to build the options)
     */
     options           : PropTypes.arrayOf( PropTypes.object ),
@@ -118,6 +124,7 @@ ListBox.defaultProps = {
     children          : undefined,
     className         : undefined,
     cssMap            : undefined,
+    id                : undefined,
     isFocusable       : true,
     isMultiselect     : false,
     onClickOption     : undefined,

--- a/src/PasswordInput/index.jsx
+++ b/src/PasswordInput/index.jsx
@@ -27,7 +27,11 @@ const PasswordInput = forwardRef( ( props, ref ) =>
     const passwordIsVisible =
         props.passwordIsVisible || passwordIsVisibleState;
 
-    const { onClickIcon } = props;
+    const {
+        id,
+        onClickIcon,
+    } = props;
+
     const handleClickIcon = useCallback( ( payload, e ) =>
     {
         let nessieDefaultPrevented = false;
@@ -36,6 +40,7 @@ const PasswordInput = forwardRef( ( props, ref ) =>
         {
             onClickIcon(
                 {
+                    id,
                     preventNessieDefault()
                     {
                         nessieDefaultPrevented = true;
@@ -49,7 +54,7 @@ const PasswordInput = forwardRef( ( props, ref ) =>
         {
             setPasswordIsVisibleState( !passwordIsVisibleState );
         }
-    }, [ onClickIcon, passwordIsVisibleState ] );
+    }, [ id, onClickIcon, passwordIsVisibleState ] );
 
     return (
         <TextInputWithIcon
@@ -58,6 +63,7 @@ const PasswordInput = forwardRef( ( props, ref ) =>
             autoComplete   = "off"
             autoCorrect    = "off"
             iconType       = { passwordIsVisible ? 'eye-off' : 'eye' }
+            id             = { id }
             inputType      = { passwordIsVisible ? 'text' : 'password' }
             onClickIcon    = { handleClickIcon }
             ref            = { ref }
@@ -105,6 +111,10 @@ PasswordInput.propTypes =
      *  Alignment of the icon
      */
     iconPosition         : PropTypes.oneOf( [ 'left', 'right' ] ),
+    /**
+     *  Component id
+     */
+    id                   : PropTypes.string,
     /**
      *  Callback that receives the native <input>: ( ref ) => { ... }
      */
@@ -157,6 +167,7 @@ PasswordInput.defaultProps =
     hasError             : false,
     iconButtonIsDisabled : undefined,
     iconPosition         : 'right',
+    id                   : undefined,
     inputRef             : undefined,
     isDisabled           : false,
     isReadOnly           : false,

--- a/src/TextArea/index.jsx
+++ b/src/TextArea/index.jsx
@@ -37,6 +37,7 @@ const TextArea = forwardRef( ( props, ref ) =>
         autoComplete,
         autoCorrect,
         defaultValue,
+        id,
         isDisabled,
         isReadOnly,
         placeholder,
@@ -55,6 +56,7 @@ const TextArea = forwardRef( ( props, ref ) =>
             className      = { cssMap.main }
             defaultValue   = { defaultValue }
             disabled       = { isDisabled }
+            id             = { id }
             placeholder    = { placeholder }
             readOnly       = { isReadOnly }
             ref            = { textAreaRef }
@@ -109,6 +111,10 @@ TextArea.propTypes =
      *  Display as error/invalid
      */
     hasError     : PropTypes.bool,
+    /**
+     *  HTML id attribute
+     */
+    id           : PropTypes.string,
     /**
      *  Display as disabled
      */
@@ -196,6 +202,7 @@ TextArea.defaultProps =
     cssMap         : undefined,
     defaultValue   : undefined,
     hasError       : false,
+    id             : undefined,
     isDisabled     : false,
     isReadOnly     : false,
     onBlur         : undefined,

--- a/src/TextInput/index.jsx
+++ b/src/TextInput/index.jsx
@@ -38,6 +38,7 @@ const TextInput = forwardRef( ( props, ref ) =>
         autoComplete,
         autoCorrect,
         defaultValue,
+        id,
         isDisabled,
         isReadOnly,
         placeholder,
@@ -55,6 +56,7 @@ const TextInput = forwardRef( ( props, ref ) =>
             className      = { cssMap.main }
             defaultValue   = { defaultValue }
             disabled       = { isDisabled }
+            id             = { id }
             placeholder    = { placeholder }
             readOnly       = { isReadOnly }
             ref            = { inputRef }
@@ -108,6 +110,10 @@ TextInput.propTypes =
      *  Display as error/invalid
      */
     hasError     : PropTypes.bool,
+    /**
+     *  HTML id attribute
+     */
+    id           : PropTypes.string,
     /**
      *  Display as disabled
      */
@@ -180,6 +186,7 @@ TextInput.defaultProps =
     cssMap         : undefined,
     defaultValue   : undefined,
     hasError       : false,
+    id             : undefined,
     isDisabled     : false,
     isReadOnly     : false,
     onBlur         : undefined,

--- a/src/TextInputWithIcon/index.jsx
+++ b/src/TextInputWithIcon/index.jsx
@@ -32,6 +32,7 @@ const TextInputWithIcon = ( props ) =>
         iconButtonIsDisabled,
         iconPosition,
         iconType,
+        id,
         inputRef,
         inputType,
         isDisabled,
@@ -65,6 +66,7 @@ const TextInputWithIcon = ( props ) =>
                 defaultValue   = { defaultValue }
                 forceHover     = { forceHover }
                 hasError       = { hasError }
+                id             = { id }
                 isDisabled     = { isDisabled }
                 isReadOnly     = { isReadOnly }
                 name           = { name }
@@ -151,6 +153,10 @@ TextInputWithIcon.propTypes =
      */
     iconType             : PropTypes.string,
     /**
+     *  Component id
+     */
+    id                   : PropTypes.string,
+    /**
      *  Callback that receives the native <input>: ( ref ) => { ... }
      */
     inputRef             : PropTypes.func,
@@ -234,6 +240,7 @@ TextInputWithIcon.defaultProps =
     iconButtonIsDisabled : false,
     iconPosition         : 'right',
     iconType             : 'none',
+    id                   : undefined,
     inputRef             : undefined,
     inputType            : 'text',
     isDisabled           : false,

--- a/src/Tooltip/index.jsx
+++ b/src/Tooltip/index.jsx
@@ -21,6 +21,7 @@ const Tooltip = props =>
 {
     const {
         children,
+        id,
         isDismissible,
         message,
         onClickClose,
@@ -32,6 +33,7 @@ const Tooltip = props =>
         <div
             { ...attachEvents( props ) }
             className = { cssMap.main }
+            id        = { id }
             role      = "tooltip">
             <div className = { cssMap.message }>
                 { children || ( typeof message === 'string' ?
@@ -84,6 +86,10 @@ Tooltip.propTypes =
      */
     cssMap        : PropTypes.objectOf( PropTypes.string ),
     /**
+     * Component id
+     */
+    id            : PropTypes.string,
+    /**
      *  Display the tooltip as user dismissible
      */
     isDismissible : PropTypes.bool,
@@ -121,6 +127,7 @@ Tooltip.defaultProps =
     children      : undefined,
     className     : undefined,
     cssMap        : undefined,
+    id            : undefined,
     isDismissible : undefined,
     message       : undefined,
     onClickClose  : undefined,


### PR DESCRIPTION
For #804:

- returned `id` prop to components where it was removed with [previous PR](https://github.com/sociomantic-tsunami/nessie-ui/pull/912)