### PR TITLE
enabled hooks dependencies linter

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -118,6 +118,7 @@
         "react/no-unused-prop-types"         : "warn",
         "react/jsx-one-expression-per-line"  : "off",
         "react-hooks/rules-of-hooks"         : "error",
+        "react-hooks/exhaustive-deps"        : "warn",
         "require-jsdoc"                      : [
             "error",
             {

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "eslint-plugin-jsx-a11y": "^6.2.1",
     "eslint-plugin-promise": "^4.0.1",
     "eslint-plugin-react": "^7.12.4",
-    "eslint-plugin-react-hooks": "^1.0.1",
+    "eslint-plugin-react-hooks": "^1.5.0",
     "loch-ness": "3.0.0-alpha.3",
     "mini-css-extract-plugin": "^0.5.0",
     "postcss": "^7.0.13",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3542,9 +3542,10 @@ eslint-plugin-promise@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/eslint-plugin-promise/-/eslint-plugin-promise-4.0.1.tgz#2d074b653f35a23d1ba89d8e976a985117d1c6a2"
 
-eslint-plugin-react-hooks@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-1.0.1.tgz#76b6fb4edafab02eab0090078977687157605dd9"
+eslint-plugin-react-hooks@^1.5.0:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-1.5.0.tgz#cdd958cfff55bd5fa4f84db90d1490fb5ca4ae2b"
+  integrity sha512-iwDuWR2ReRgvJsNm8fXPtTKdg78IVQF8I4+am3ntztPf/+nPnWZfArFu6aXpaC75/iCYRrkqI8nPCYkxJstmpA==
 
 eslint-plugin-react@^7.12.4:
   version "7.12.4"


### PR DESCRIPTION
- Upgrading `eslint-plugin-react-hooks`.
- Enabling exhaustive-deps rule .