### PR TITLE
Issue 802 ComboBox without options

### DIFF
--- a/src/ComboBox/index.jsx
+++ b/src/ComboBox/index.jsx
@@ -636,7 +636,7 @@ ComboBox.defaultProps =
     isSearchable        : false,
     onChange            : undefined,
     onChangeInput       : undefined,
-    options             : undefined,
+    options             : [],
     value               : undefined,
 };
 


### PR DESCRIPTION
For #802:

- updated default prop value for `options` to be an empty array