### PR TITLE
:bug: Check whether the position has changed before calling setState

### DIFF
--- a/src/ComboBox/index.jsx
+++ b/src/ComboBox/index.jsx
@@ -406,7 +406,7 @@ export default class ComboBox extends Component
     {
         let { dropdownPosition } = props;
 
-        if ( props.dropdownPosition === 'auto' )
+        if ( dropdownPosition === 'auto' )
         {
             const { wrapperRef } = this;
 
@@ -428,7 +428,10 @@ export default class ComboBox extends Component
             }
         }
 
-        this.setState( { dropdownPosition } );
+        if ( dropdownPosition !== this.state.dropdownPosition )
+        {
+            this.setState( { dropdownPosition } );
+        }
     }
 
     handleClickOption( e, optId )


### PR DESCRIPTION
I've added a check for the dropdown position change to avoid calling `setState` every time.