### PR TITLE
Pass thru ref

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,15 @@
 # Nessie
 
 Nessie is the dunnhumby media UI component library.
+
+## Focus Management
+
+Don’t use `ref`s for focus management. By convention we always return the
+outermost element of a given component as `ref`. This is not necessarily the
+thing that should receive focus.
+
+Instead, pass a unique `id` to the component and use
+`document.getElementById(myId).focus()` to focus it.
+
+We’ll always make sure that the DOM element with `id` is the thing that you want
+to focus.

--- a/src/Button/index.jsx
+++ b/src/Button/index.jsx
@@ -7,28 +7,18 @@
  *
  */
 
-import React, {
-    useImperativeHandle,
-    useRef,
-    forwardRef,
-} from 'react';
-import PropTypes                           from 'prop-types';
+import React, { forwardRef }              from 'react';
+import PropTypes                          from 'prop-types';
 
-import { Icon, Spinner }                   from '..';
+import { Icon, Spinner }                  from '..';
 
-import { attachEvents, useThemeClasses }   from '../utils';
+import { attachEvents, useThemeClasses }  from '../utils';
 
 
 const componentName = 'Button';
 
 const Button = forwardRef( ( props, ref ) =>
 {
-    const buttonRef = useRef();
-
-    useImperativeHandle( ref, () => ( {
-        focus : () => buttonRef.current.focus(),
-    } ) );
-
     const {
         children,
         iconType,
@@ -47,7 +37,7 @@ const Button = forwardRef( ( props, ref ) =>
             className = { cssMap.main }
             disabled  = { isDisabled }
             id        = { id }
-            ref       = { buttonRef }
+            ref       = { ref }
             style     = { style }
             type      = "button">
             <div className = { cssMap.content }>

--- a/src/Card/index.jsx
+++ b/src/Card/index.jsx
@@ -7,7 +7,7 @@
  *
  */
 
-import React                             from 'react';
+import React, { forwardRef }             from 'react';
 import PropTypes                         from 'prop-types';
 
 import { attachEvents, useThemeClasses } from '../utils';
@@ -15,7 +15,7 @@ import { attachEvents, useThemeClasses } from '../utils';
 
 const componentName = 'Card';
 
-const Card = props =>
+const Card = forwardRef( ( props, ref ) =>
 {
     const { children, style } = props;
 
@@ -25,11 +25,12 @@ const Card = props =>
         <div
             { ...attachEvents( props ) }
             className = { cssMap.main }
+            ref       = { ref }
             style     = { style }>
             { children }
         </div>
     );
-};
+} );
 
 Card.propTypes =
 {

--- a/src/Checkbox/index.jsx
+++ b/src/Checkbox/index.jsx
@@ -8,14 +8,10 @@
  */
 
 
-import React, {
-    useImperativeHandle,
-    useRef,
-    forwardRef,
-} from 'react';
-import PropTypes    from 'prop-types';
+import React, { forwardRef } from 'react';
+import PropTypes             from 'prop-types';
 
-import { Text }     from '..';
+import { Text }              from '..';
 
 import {
     attachEvents,
@@ -28,12 +24,6 @@ const componentName = 'Checkbox';
 
 const Checkbox = forwardRef( ( props, ref ) =>
 {
-    const checkBoxRef = useRef();
-
-    useImperativeHandle( ref, () => ( {
-        focus : () => checkBoxRef.current.focus(),
-    } ) );
-
     const {
         children,
         isChecked,
@@ -55,7 +45,7 @@ const Checkbox = forwardRef( ( props, ref ) =>
     }
 
     return (
-        <div className = { cssMap.main } style = { style }>
+        <div className = { cssMap.main } ref = { ref } style = { style }>
             <input
                 { ...attachEvents( props ) }
                 checked   = { isChecked }

--- a/src/ComboBox/index.jsx
+++ b/src/ComboBox/index.jsx
@@ -484,77 +484,75 @@ const ComboBox = forwardRef( ( props, ref ) =>
         );
     }
 
-    const popperChildren = (
-        <label
-            { ...attachEvents( props ) }
-            className = { cssMap.main }
-            htmlFor   = { id }>
-            { tags }
-            <input
-                { ...mapAria( {
-                    activeDescendant :
-                        activeOption && addPrefix( activeOption, id ),
-                    autocomplete : 'list',
-                    expanded     : isOpen,
-                    hasPopup     : 'listbox',
-                    owns         : addPrefix( 'listbox', id ),
-                    role         : 'combobox',
-                } ) }
-                autoCapitalize = "off"
-                autoComplete   = "off"
-                autoCorrect    = "off"
-                className      = { cssMap.input }
-                disabled       = { isDisabled }
-                id             = { id }
-                onBlur         = { callMultiple(
-                    handleBlur,
-                    props.onBlur,
-                ) } // temporary fix
-                onChange       = { handleChangeInput }
-                onClick        = { callMultiple(
-                    handleClick,
-                    props.onClick,
-                ) } // temporary fix
-                onFocus        = { callMultiple(
-                    handleFocus,
-                    props.onFocus,
-                ) } // temporary fix
-                onKeyDown      = { callMultiple(
-                    handleKeyDown,
-                    props.onKeyDown,
-                ) } // temporary fix
-                placeholder    = { inputPlaceholder }
-                readOnly       = { !isSearchable || !isOpen }
-                spellCheck     = { false }
-                value          = { ( isOpen && isSearchable ) ?
-                    searchValue : selectedText } />
-            <IconButton
-                className   = { cssMap.icon }
-                iconType    = { isOpen ? 'chevron-up' : 'chevron-down' }
-                isFocusable = { false }
-                onClick     = { handleClickIcon } />
-        </label>
-    );
-
-    const popperPopup = (
-        <Popup
-            hasError = { hasError }
-            padding  = { optionsToShow.length ? 'none' : 'S' }>
-            { dropdownContent }
-        </Popup>
-    );
-
     return (
         <PopperWrapper
             popperContainer = { popperContainer }
             isVisible       = { isOpen }
             matchRefWidth
-            popper          = { popperPopup }
+            popper          = { ( { ...popperProps } ) => (
+                <Popup
+                    { ...popperProps }
+                    hasError = { hasError }
+                    padding  = { optionsToShow.length ? 'none' : 'S' }>
+                    { dropdownContent }
+                </Popup>
+            ) }
             popperOffset    = "S"
             popperPosition  = "bottom"
             ref             = { ref }
             style           = { style }>
-            { popperChildren }
+            { ( { ref: innerRef } ) => (
+                <label
+                    { ...attachEvents( props ) }
+                    className = { cssMap.main }
+                    htmlFor   = { id }
+                    ref       = { innerRef }>
+                    { tags }
+                    <input
+                        { ...mapAria( {
+                            activeDescendant :
+                              activeOption && addPrefix( activeOption, id ),
+                            autocomplete : 'list',
+                            expanded     : isOpen,
+                            hasPopup     : 'listbox',
+                            owns         : addPrefix( 'listbox', id ),
+                            role         : 'combobox',
+                        } ) }
+                        autoCapitalize = "off"
+                        autoComplete   = "off"
+                        autoCorrect    = "off"
+                        className      = { cssMap.input }
+                        disabled       = { isDisabled }
+                        id             = { id }
+                        onBlur         = { callMultiple(
+                            handleBlur,
+                            props.onBlur,
+                        ) } // temporary fix
+                        onChange       = { handleChangeInput }
+                        onClick        = { callMultiple(
+                            handleClick,
+                            props.onClick,
+                        ) } // temporary fix
+                        onFocus        = { callMultiple(
+                            handleFocus,
+                            props.onFocus,
+                        ) } // temporary fix
+                        onKeyDown      = { callMultiple(
+                            handleKeyDown,
+                            props.onKeyDown,
+                        ) } // temporary fix
+                        placeholder    = { inputPlaceholder }
+                        readOnly       = { !isSearchable || !isOpen }
+                        spellCheck     = { false }
+                        value          = { ( isOpen && isSearchable ) ?
+                            searchValue : selectedText } />
+                    <IconButton
+                        className   = { cssMap.icon }
+                        iconType    = { isOpen ? 'chevron-up' : 'chevron-down' }
+                        isFocusable = { false }
+                        onClick     = { handleClickIcon } />
+                </label>
+            ) }
         </PopperWrapper>
     );
 } );

--- a/src/ComboBox/index.jsx
+++ b/src/ComboBox/index.jsx
@@ -10,6 +10,7 @@
 /* global document */
 
 import React, {
+    forwardRef,
     useCallback,
     useEffect,
     useMemo,
@@ -22,8 +23,8 @@ import { castArray, escapeRegExp }  from 'lodash';
 import {
     IconButton,
     ListBox,
-    Popup,
     PopperWrapper,
+    Popup,
     ScrollBox,
     Text,
 } from '..';
@@ -131,7 +132,7 @@ const useSelection = ( defaultValue, value, isMultiselect ) =>
 
 const componentName = 'ComboBox';
 
-const ComboBox = props =>
+const ComboBox = forwardRef( ( props, ref ) =>
 {
     const cssMap = useThemeClasses( componentName, props );
     const id = useId( componentName, props );
@@ -140,7 +141,6 @@ const ComboBox = props =>
     const [ isOpen, setIsOpen ] = useState( undefined );
     const [ searchValue, setSearchValue ] = useState( undefined );
 
-    const inputRef = useRef( null );
     const scrollBoxRef = useRef( null );
 
     const {
@@ -221,8 +221,8 @@ const ComboBox = props =>
 
     const focus = useCallback( () =>
     {
-        inputRef.current.focus();
-    }, [] );
+        document.getElementById( id ).focus();
+    }, [ id ] );
 
     const handleFocus = useCallback( () =>
     {
@@ -378,7 +378,18 @@ const ComboBox = props =>
                 }
             }
         }
-    }, [ filteredOptions, flatOptions, isOpen, activeOption, selection, isReadOnly, isMultiselect, onChange, setSelection, id ] );
+    }, [
+        activeOption,
+        filteredOptions,
+        flatOptions,
+        id,
+        isMultiselect,
+        isOpen,
+        isReadOnly,
+        onChange,
+        selection,
+        setSelection,
+    ] );
 
     const handleMouseOutOption = useCallback( () =>
     {
@@ -514,7 +525,6 @@ const ComboBox = props =>
                 ) } // temporary fix
                 placeholder    = { inputPlaceholder }
                 readOnly       = { !isSearchable || !isOpen }
-                ref            = { inputRef }
                 spellCheck     = { false }
                 value          = { ( isOpen && isSearchable ) ?
                     searchValue : selectedText } />
@@ -542,11 +552,12 @@ const ComboBox = props =>
             popper          = { popperPopup }
             popperOffset    = "S"
             popperPosition  = "bottom"
+            ref             = { ref }
             style           = { style }>
             { popperChildren }
         </PopperWrapper>
     );
-};
+} );
 
 ComboBox.propTypes =
 {

--- a/src/CurrencyInput/index.jsx
+++ b/src/CurrencyInput/index.jsx
@@ -9,10 +9,10 @@
 
 /* global navigator */
 
-import React, { useState } from 'react';
-import PropTypes           from 'prop-types';
+import React, { forwardRef, useState } from 'react';
+import PropTypes                       from 'prop-types';
 
-import { TextInput }       from '..';
+import { TextInput }                   from '..';
 
 
 const currencyFormat = ( number, currency, language = navigator.language ) =>
@@ -24,7 +24,7 @@ const pattern = /[^0-9.-]/g;
 
 const componentName = 'CurrencyInput';
 
-const CurrencyInput = ( props ) =>
+const CurrencyInput = forwardRef( ( props, ref ) =>
 {
     const {
         currency,
@@ -66,14 +66,15 @@ const CurrencyInput = ( props ) =>
             autoComplete   = "off"
             autoCorrect    = "off"
             id             = { id }
-            spellCheck     = { false }
             onBlur         = { handleBlur }
             onChange       = { handleChange }
+            ref            = { ref }
+            spellCheck     = { false }
             style          = { style }
             value          = { currencyFormat( Number( value
                 .replace( pattern, '' ) ) || valueState, currency ) } />
     );
-};
+} );
 
 CurrencyInput.propTypes =
 {
@@ -183,9 +184,9 @@ CurrencyInput.defaultProps =
     onMouseOut   : undefined,
     onMouseOver  : undefined,
     placeholder  : undefined,
+    style        : undefined,
     textAlign    : 'left',
     value        : '',
-    style        : undefined,
 };
 
 CurrencyInput.displayName = componentName;

--- a/src/DatePicker/DatePickerHeader.jsx
+++ b/src/DatePicker/DatePickerHeader.jsx
@@ -7,18 +7,18 @@
  *
  */
 
-import React                       from 'react';
-import PropTypes                   from 'prop-types';
+import React, { forwardRef } from 'react';
+import PropTypes             from 'prop-types';
 
-import { IconButton, Text }        from '..';
+import { IconButton, Text }  from '..';
 
-import TimeInput                   from './TimeInput';
-import { useThemeClasses }         from '../utils';
+import TimeInput             from './TimeInput';
+import { useThemeClasses }   from '../utils';
 
 
 const componentName = 'DatePickerHeader';
 
-const DatePickerHeader = props =>
+const DatePickerHeader = forwardRef( ( props, ref ) =>
 {
     const cssMap = useThemeClasses( componentName, props );
 
@@ -46,7 +46,7 @@ const DatePickerHeader = props =>
     } = props;
 
     return (
-        <div className = { cssMap.main } style = { style }>
+        <div className = { cssMap.main } ref = { ref } style = { style }>
             <div className = { cssMap.buttonsWrapper }>
                 <IconButton
                     className  = { cssMap.prev }
@@ -82,7 +82,7 @@ const DatePickerHeader = props =>
             }
         </div>
     );
-};
+} );
 
 DatePickerHeader.propTypes = {
     className         : PropTypes.string,

--- a/src/DatePicker/DatePickerItem.jsx
+++ b/src/DatePicker/DatePickerItem.jsx
@@ -7,17 +7,17 @@
  *
  */
 
-import React                              from 'react';
-import PropTypes                          from 'prop-types';
+import React, { forwardRef }             from 'react';
+import PropTypes                         from 'prop-types';
 
-import { Text }                           from '..';
+import { Text }                          from '..';
 
-import { attachEvents, useThemeClasses }  from '../utils';
+import { attachEvents, useThemeClasses } from '../utils';
 
 
 const componentName = 'DatePickerItem';
 
-const DatePickerItem = props =>
+const DatePickerItem = forwardRef( ( props, ref ) =>
 {
     const cssMap = useThemeClasses( componentName, props );
 
@@ -38,13 +38,14 @@ const DatePickerItem = props =>
             aria-pressed = { isSelected }
             className    = { cssMap.main }
             disabled     = { isDisabled }
+            ref          = { ref }
             style        = { style }
             type         = "button"
             value        = { value }>
             <Text className = { cssMap.text }>{ children || label }</Text>
         </button>
     );
-};
+} );
 
 DatePickerItem.propTypes = {
     children   : PropTypes.node,
@@ -54,8 +55,8 @@ DatePickerItem.propTypes = {
     isSelected : PropTypes.bool,
     label      : PropTypes.string,
     onClick    : PropTypes.func,
-    value      : PropTypes.string,
     type       : PropTypes.oneOf( [ 'day', 'month' ] ),
+    value      : PropTypes.string,
     /**
      *  Style overrides
      */

--- a/src/DatePicker/TimeInput.jsx
+++ b/src/DatePicker/TimeInput.jsx
@@ -7,18 +7,15 @@
  *
  */
 
-import React      from 'react';
-import PropTypes  from 'prop-types';
+import React, { forwardRef }                   from 'react';
+import PropTypes                               from 'prop-types';
 
-import {
-    createEventHandler,
-    useThemeClasses,
-} from '../utils';
+import { createEventHandler, useThemeClasses } from '../utils';
 
 
 const componentName = 'TimeInput';
 
-const TimeInput = props =>
+const TimeInput = forwardRef( ( props, ref ) =>
 {
     const cssMap = useThemeClasses( componentName, props );
 
@@ -40,7 +37,7 @@ const TimeInput = props =>
     } = props;
 
     return (
-        <div className = { cssMap.main } style = { style }>
+        <div className = { cssMap.main } ref = { ref } style = { style }>
             <input
                 className   = { cssMap.hour }
                 disabled    = { isDisabled || hourIsDisabled }
@@ -62,7 +59,7 @@ const TimeInput = props =>
                 value       = { minuteValue } />
         </div>
     );
-};
+} );
 
 TimeInput.propTypes =
 {

--- a/src/DatePicker/index.jsx
+++ b/src/DatePicker/index.jsx
@@ -7,15 +7,15 @@
  *
  */
 
-import React, { useState }                from 'react';
-import PropTypes                          from 'prop-types';
-import moment                             from 'moment';
-import _                                  from 'lodash';
+import React, { forwardRef, useState }   from 'react';
+import PropTypes                         from 'prop-types';
+import moment                            from 'moment';
+import _                                 from 'lodash';
 
-import copy                               from './copy.json';
-import DatePickerItem                     from './DatePickerItem';
-import DatePickerHeader                   from './DatePickerHeader';
-import { attachEvents, useThemeClasses }  from '../utils';
+import copy                              from './copy.json';
+import DatePickerItem                    from './DatePickerItem';
+import DatePickerHeader                  from './DatePickerHeader';
+import { attachEvents, useThemeClasses } from '../utils';
 
 
 const DAY_LABELS = _.range( 0, 7 ).map( day => ( {
@@ -94,7 +94,7 @@ const useTimestamp = ( defaultValue = Date.now(), value ) =>
 
 const componentName = 'DatePicker';
 
-const DatePicker = props =>
+const DatePicker = forwardRef( ( props, ref ) =>
 {
     const [ timestamp, setTimestamp ] = useTimestamp(
         props.defaultValue,
@@ -353,6 +353,7 @@ const DatePicker = props =>
         <div
             { ...attachEvents( restProps ) }
             className = { cssMap.main }
+            ref       = { ref }
             style     = { style }>
             <DatePickerHeader
                 hasTimeInput      = { hasTimeInput }
@@ -408,7 +409,7 @@ const DatePicker = props =>
             }
         </div>
     );
-};
+} );
 
 DatePicker.propTypes = {
     className    : PropTypes.string,

--- a/src/DateTimeInput/index.jsx
+++ b/src/DateTimeInput/index.jsx
@@ -8,6 +8,7 @@
  */
 
 import React, {
+    forwardRef,
     useCallback,
     useImperativeHandle,
     useRef,
@@ -131,13 +132,6 @@ const useTimestamp = ( defaultValue, value ) =>
 
 const DateTimeInput = React.forwardRef( ( props, ref ) =>
 {
-    const inputRef = useRef();
-
-    useImperativeHandle( ref, () => ( {
-        focus : () => inputRef.current.focus(),
-    } ) );
-
-
     const [ editingMainInputValue, setEditingMainInputValue ] =
         useState( undefined );
     const [ gridStartTimestamp, setGridStartTimestamp ] = useState( undefined );
@@ -280,7 +274,6 @@ const DateTimeInput = React.forwardRef( ( props, ref ) =>
             hasError       = { hasError }
             iconType       = "calendar"
             id             = { id }
-            inputRef       = { inputRef }
             isDisabled     = { isDisabled }
             isReadOnly     = { isReadOnly }
             onBlur         = { handleOnBlur }
@@ -308,6 +301,7 @@ const DateTimeInput = React.forwardRef( ( props, ref ) =>
             popperContainer = { popperContainer }
             popperOffset    = "S"
             popperPosition  = "bottom-start"
+            ref             = { ref }
             style           = { style }>
             { popperChildren }
         </PopperWrapper>

--- a/src/DateTimeInput/index.jsx
+++ b/src/DateTimeInput/index.jsx
@@ -10,8 +10,6 @@
 import React, {
     forwardRef,
     useCallback,
-    useImperativeHandle,
-    useRef,
     useState,
 } from 'react';
 import PropTypes            from 'prop-types';
@@ -130,7 +128,7 @@ const useTimestamp = ( defaultValue, value ) =>
 };
 
 
-const DateTimeInput = React.forwardRef( ( props, ref ) =>
+const DateTimeInput = forwardRef( ( props, ref ) =>
 {
     const [ editingMainInputValue, setEditingMainInputValue ] =
         useState( undefined );

--- a/src/DateTimeInput/index.jsx
+++ b/src/DateTimeInput/index.jsx
@@ -263,45 +263,48 @@ const DateTimeInput = forwardRef( ( props, ref ) =>
             value            = { timestamp } />
     );
 
-    const popperChildren = (
-        <TextInputWithIcon
-            autoCapitalize = "off"
-            autoComplete   = "off"
-            autoCorrect    = "off"
-            className      = { className }
-            hasError       = { hasError }
-            iconType       = "calendar"
-            id             = { id }
-            isDisabled     = { isDisabled }
-            isReadOnly     = { isReadOnly }
-            onBlur         = { handleOnBlur }
-            onChangeInput  = { handleChangeInput }
-            onClickIcon    = { handleClickIcon }
-            placeholder    = { inputPlaceholder }
-            spellCheck     = { false }
-            value          = { editingMainInputValue ||
-                formatDateTime( timestamp, format || setPrecision( mode ) )
-            } />
-    );
-
-    const popperPopup = (
-        <Popup
-            hasError = { hasError }>
-            { datePicker }
-        </Popup>
-    );
 
     return (
         <PopperWrapper
             isVisible       = { isOpen }
             onClickOutside  = { close }
-            popper          = { popperPopup }
+            popper          = { popperProps => (
+                <Popup
+                    hasError = { hasError }
+                    size     = "content"
+                    { ...popperProps }>
+                    { datePicker }
+                </Popup>
+            ) }
             popperContainer = { popperContainer }
             popperOffset    = "S"
             popperPosition  = "bottom-start"
             ref             = { ref }
             style           = { style }>
-            { popperChildren }
+            { refProps => (
+                <TextInputWithIcon
+                    autoCapitalize = "off"
+                    autoComplete   = "off"
+                    autoCorrect    = "off"
+                    className      = { className }
+                    hasError       = { hasError }
+                    iconType       = "calendar"
+                    id             = { id }
+                    isDisabled     = { isDisabled }
+                    isReadOnly     = { isReadOnly }
+                    onBlur         = { handleOnBlur }
+                    onChangeInput  = { handleChangeInput }
+                    onClickIcon    = { handleClickIcon }
+                    placeholder    = { inputPlaceholder }
+                    spellCheck     = { false }
+                    value          = { editingMainInputValue ||
+                        formatDateTime(
+                            timestamp,
+                            format || setPrecision( mode ),
+                        )
+                    }
+                    { ...refProps } />
+            ) }
         </PopperWrapper>
     );
 } );

--- a/src/DefaultTheme.js
+++ b/src/DefaultTheme.js
@@ -184,7 +184,6 @@ const classNames = {
             'default',
             { error: props.hasError },
             `padding__${props.padding}`,
-            `size__${props.size}`,
             props.className,
         ),
         ...popupClasses,

--- a/src/Grid/index.jsx
+++ b/src/Grid/index.jsx
@@ -7,15 +7,15 @@
  *
  */
 
-import React                               from 'react';
-import PropTypes                           from 'prop-types';
+import React, { forwardRef }             from 'react';
+import PropTypes                         from 'prop-types';
 
-import { attachEvents, useThemeClasses }   from '../utils';
+import { attachEvents, useThemeClasses } from '../utils';
 
 
 const componentName = 'Grid';
 
-const Grid = props =>
+const Grid = forwardRef( ( props, ref ) =>
 {
     const {
         autoCols,
@@ -34,6 +34,7 @@ const Grid = props =>
         <div
             { ...attachEvents( props ) }
             className = { cssMap.main }
+            ref       = { ref }
             style     = { {
                 gridAutoColumns     : autoCols,
                 gridAutoRows        : autoRows,
@@ -45,7 +46,7 @@ const Grid = props =>
             { children }
         </div>
     );
-};
+} );
 
 Grid.propTypes =
 {

--- a/src/GridItem/index.jsx
+++ b/src/GridItem/index.jsx
@@ -7,7 +7,7 @@
  *
  */
 
-import React                             from 'react';
+import React, { forwardRef }             from 'react';
 import PropTypes                         from 'prop-types';
 
 import { attachEvents, useThemeClasses } from '../utils';
@@ -15,7 +15,7 @@ import { attachEvents, useThemeClasses } from '../utils';
 
 const componentName = 'GridItem';
 
-const GridItem = props =>
+const GridItem = forwardRef( ( props, ref ) =>
 {
     const {
         children,
@@ -30,6 +30,7 @@ const GridItem = props =>
         <div
             { ...attachEvents( props ) }
             className = { cssMap.main }
+            ref       = { ref }
             style     = { {
                 gridColumn : `span ${colSpan}`,
                 gridRow    : `span ${rowSpan}`,
@@ -38,7 +39,7 @@ const GridItem = props =>
             { children }
         </div>
     );
-};
+} );
 
 GridItem.propTypes =
 {

--- a/src/Icon/index.jsx
+++ b/src/Icon/index.jsx
@@ -7,7 +7,7 @@
  *
  */
 
-import React                             from 'react';
+import React, { forwardRef }             from 'react';
 import PropTypes                         from 'prop-types';
 
 import { attachEvents, useThemeClasses } from '../utils';
@@ -15,7 +15,7 @@ import { attachEvents, useThemeClasses } from '../utils';
 
 const componentName = 'Icon';
 
-const Icon = props =>
+const Icon = forwardRef( ( props, ref ) =>
 {
     const {
         children,
@@ -31,12 +31,13 @@ const Icon = props =>
             { ...attachEvents( props ) }
             aria-label = { children || label }
             className  = { cssMap.main }
-            style = { style }>
+            ref        = { ref }
+            style      = { style }>
             { ( type !== 'none' ) &&
             <use xlinkHref = { `#nessie-${type}` } /> }
         </svg>
     );
-};
+} );
 
 Icon.propTypes =
 {

--- a/src/IconButton/index.jsx
+++ b/src/IconButton/index.jsx
@@ -7,7 +7,7 @@
  *
  */
 
-import React                             from 'react';
+import React, { forwardRef }             from 'react';
 import PropTypes                         from 'prop-types';
 
 import { Icon }                          from '..';
@@ -19,10 +19,9 @@ const componentName = 'IconButton';
 
 const killFocus = e => e.preventDefault();
 
-const IconButton = props =>
+const IconButton = forwardRef( ( props, ref ) =>
 {
     const {
-        buttonRef,
         children,
         iconSize,
         iconType,
@@ -45,7 +44,7 @@ const IconButton = props =>
             disabled    = { isDisabled }
             id          = { id }
             onMouseDown = { !isFocusable ? killFocus : undefined }
-            ref         = { buttonRef }
+            ref         = { ref }
             style       = { style }
             tabIndex    = { isFocusable ? '0' : '-1' }
             type        = "button"
@@ -59,14 +58,10 @@ const IconButton = props =>
             </Icon>
         </button>
     );
-};
+} );
 
 IconButton.propTypes =
 {
-    /**
-     * Callback that receives a ref to the <button>: ( ref ) => { ... }
-     */
-    buttonRef     : PropTypes.func,
     /**
      *  extra CSS class name
      */
@@ -127,7 +122,6 @@ IconButton.propTypes =
 
 IconButton.defaultProps =
 {
-    buttonRef     : undefined,
     children      : undefined,
     className     : undefined,
     cssMap        : undefined,

--- a/src/ListBox/ListBoxOption.jsx
+++ b/src/ListBox/ListBoxOption.jsx
@@ -11,10 +11,10 @@
 /* eslint-disable jsx-a11y/no-noninteractive-element-interactions */
 /* eslint-disable jsx-a11y/no-noninteractive-tabindex */
 
-import React            from 'react';
-import PropTypes        from 'prop-types';
+import React, { forwardRef } from 'react';
+import PropTypes             from 'prop-types';
 
-import { Icon, Text }   from '..';
+import { Icon, Text }        from '..';
 
 import {
     attachEvents,
@@ -26,7 +26,7 @@ import {
 
 const componentName = 'ListBoxOption';
 
-const ListBoxOption = props =>
+const ListBoxOption = forwardRef( ( props, ref ) =>
 {
     const {
         aria,
@@ -69,11 +69,12 @@ const ListBoxOption = props =>
             } ) }
             { ...mapAria( {
                 ...aria,
-                selected : isSelected,
                 role     : 'option',
+                selected : isSelected,
             } ) }
             className   = { cssMap.main }
             id          = { id }
+            ref         = { ref }
             style       = { style }>
             { ( iconType && iconType !== 'none' ) &&
                 <Icon
@@ -93,7 +94,7 @@ const ListBoxOption = props =>
             </div>
         </li>
     );
-};
+} );
 
 ListBoxOption.propTypes = {
     aria        : PropTypes.objectOf( PropTypes.string ),

--- a/src/ListBox/ListBoxOptionGroup.jsx
+++ b/src/ListBox/ListBoxOptionGroup.jsx
@@ -7,17 +7,17 @@
  *
  */
 
-import React                           from 'react';
-import PropTypes                       from 'prop-types';
+import React, { forwardRef }        from 'react';
+import PropTypes                    from 'prop-types';
 
-import { Text }                        from '..';
+import { Text }                     from '..';
 
-import { mapAria, useThemeClasses }    from '../utils';
+import { mapAria, useThemeClasses } from '../utils';
 
 
 const componentName = 'ListBoxOptionGroup';
 
-const ListBoxOptionGroup = props =>
+const ListBoxOptionGroup = forwardRef( ( props, ref ) =>
 {
     const {
         aria,
@@ -33,6 +33,7 @@ const ListBoxOptionGroup = props =>
         <li
             { ...mapAria( { ...aria, role: 'none' } ) }
             className = { cssMap.main }
+            ref       = { ref }
             style     = { style }>
             <div className = { cssMap.header }>
                 <Text className = { cssMap.headerText }>{ header }</Text>
@@ -48,7 +49,7 @@ const ListBoxOptionGroup = props =>
             </ul>
         </li>
     );
-};
+} );
 
 ListBoxOptionGroup.propTypes = {
     aria      : PropTypes.objectOf( PropTypes.string ),

--- a/src/ListBox/index.jsx
+++ b/src/ListBox/index.jsx
@@ -10,7 +10,7 @@
 /* eslint-disable jsx-a11y/no-noninteractive-element-interactions */
 /* eslint-disable jsx-a11y/no-noninteractive-tabindex */
 
-import React                           from 'react';
+import React, { forwardRef }           from 'react';
 import PropTypes                       from 'prop-types';
 
 import { buildOptions, updateOptions } from './utils';
@@ -24,7 +24,7 @@ import {
 
 const componentName = 'ListBox';
 
-const ListBox = props =>
+const ListBox = forwardRef( ( props, ref ) =>
 {
     const {
         aria,
@@ -61,6 +61,7 @@ const ListBox = props =>
             className   = { cssMap.main }
             id          = { id }
             onMouseDown = { !isFocusable ? killFocus : undefined }
+            ref         = { ref }
             style       = { style }
             tabIndex    = { isFocusable ? '0' : '-1' }>
             { updateOptions(
@@ -75,7 +76,7 @@ const ListBox = props =>
             ) }
         </ul>
     );
-};
+} );
 
 ListBox.propTypes = {
     aria              : PropTypes.objectOf( PropTypes.string ),

--- a/src/Modal/index.jsx
+++ b/src/Modal/index.jsx
@@ -7,15 +7,15 @@
  *
  */
 
-import React                               from 'react';
-import PropTypes                           from 'prop-types';
+import React, { forwardRef }             from 'react';
+import PropTypes                         from 'prop-types';
 
-import { attachEvents, useThemeClasses }   from '../utils';
+import { attachEvents, useThemeClasses } from '../utils';
 
 
 const componentName = 'Modal';
 
-const Modal = ( props ) =>
+const Modal = forwardRef( ( props, ref ) =>
 {
     const handleClickOverlay = ( { target, currentTarget } ) =>
     {
@@ -35,16 +35,16 @@ const Modal = ( props ) =>
     return (
         <div
             { ...attachEvents( props, { onClick: false } ) }
-            onClick   = { handleClickOverlay }
             className = { cssMap.main }
-            style     = { style }
-        >
+            onClick   = { handleClickOverlay }
+            ref       = { ref }
+            style     = { style }>
             <div className = { cssMap.content }>
                 { children }
             </div>
         </div>
     );
-};
+} );
 
 Modal.propTypes =
 {

--- a/src/PasswordInput/index.jsx
+++ b/src/PasswordInput/index.jsx
@@ -8,13 +8,13 @@
  */
 
 import React, {
-    useState,
-    useCallback,
     forwardRef,
-}                               from 'react';
-import PropTypes                from 'prop-types';
+    useCallback,
+    useState,
+}                            from 'react';
+import PropTypes             from 'prop-types';
 
-import { TextInputWithIcon }    from '..';
+import { TextInputWithIcon } from '..';
 
 
 const componentName = 'PasswordInput';
@@ -114,10 +114,6 @@ PasswordInput.propTypes =
      */
     id                   : PropTypes.string,
     /**
-     *  Callback that receives the native <input>: ( ref ) => { ... }
-     */
-    inputRef             : PropTypes.func,
-    /**
      *  Display as disabled
      */
     isDisabled           : PropTypes.bool,
@@ -169,7 +165,6 @@ PasswordInput.defaultProps =
     iconButtonIsDisabled : undefined,
     iconPosition         : 'right',
     id                   : undefined,
-    inputRef             : undefined,
     isDisabled           : false,
     isReadOnly           : false,
     name                 : undefined,

--- a/src/PopperWrapper/README.md
+++ b/src/PopperWrapper/README.md
@@ -17,11 +17,30 @@ it ( as long as `container` prop keeps its default value ).
 
 ## Example Usage
 
+`children` and `popper` are render props (i.e. they expect a function) and
+should be used as follows:
 ```
 <PopperWrapper
-    popper         = "Popup content"
+    popper = { popperProps => <MyPopupComponent {...propperProps}/> }>
+    { refProps =>
+        <MyWrappedComponent {...refProps} />
+    }
+</PopperWrapper>
+```
+
+For example:
+
+```
+<PopperWrapper
+    popper = { popperProps => (
+      <Popup {...propperProps}>
+        Popup content
+      </Popup>
+    ) }
     popperPosition = "bottom">
-    <Button label = "Click me!"/>
+    { refProps =>
+         <Button {...refProps}>Click me!</Button>
+    }
 </PopperWrapper>
 
 ```

--- a/src/PopperWrapper/README.md
+++ b/src/PopperWrapper/README.md
@@ -15,32 +15,50 @@ conflicts / overlaps with some other stuff ) you can add an extra div with
 `<body>`, if this div exists _PopperWrapper_ will always render the popup inside
 it ( as long as `container` prop keeps its default value ).
 
-## Example Usage
-
-`children` and `popper` are render props (i.e. they expect a function) and
-should be used as follows:
+`children` and `popper` can be used as render props (i.e. functions that return
+a React element) as follows:
 ```
 <PopperWrapper
-    popper = { popperProps => <MyPopupComponent {...propperProps}/> }>
-    { refProps =>
-        <MyWrappedComponent {...refProps} />
+    popper = { popperProps => <MyPopupComponent {...popperProps} /> }>
+    { referenceProps =>
+        <MyReferenceComponent {...referenceProps} />
     }
 </PopperWrapper>
 ```
 
-For example:
+or as React elements as follows:
+```
+<PopperWrapper
+    popper = { <MyPopupComponent /> }>
+    <MyReferenceComponent />
+</PopperWrapper>
+```
 
+**If you pass react elements PopperWrapper will call `React.cloneElement` to
+inject the required props into the `children` and `popper`.**
+
+## Example Usage
+
+Using render props:
 ```
 <PopperWrapper
     popper = { popperProps => (
-      <Popup {...propperProps}>
-        Popup content
-      </Popup>
+        <Popup {...popperProps}>
+            Popup content
+        </Popup>
     ) }
     popperPosition = "bottom">
     { refProps =>
-         <Button {...refProps}>Click me!</Button>
+        <Button {...refProps}>Click me!</Button>
     }
 </PopperWrapper>
+```
 
+Using elements:
+```
+<PopperWrapper
+    popper         = { <Popup>Popup content</Popup> }
+    popperPosition = "bottom">
+    <Button {...refProps}>Click me!</Button>
+</PopperWrapper>
 ```

--- a/src/PopperWrapper/index.jsx
+++ b/src/PopperWrapper/index.jsx
@@ -97,7 +97,7 @@ const PopperWrapper = forwardRef( ( props, forwardedRef ) =>
                     offset : `0, ${offset}`,
                 },
             } : offset }>
-            { ( { style : popperStyle, scheduleUpdate, ...rest } ) =>
+            { ( { style : popperStyle, scheduleUpdate, ref } ) =>
             {
                 scheduleUpdateRef.current = scheduleUpdate;
                 return popper( {
@@ -106,7 +106,7 @@ const PopperWrapper = forwardRef( ( props, forwardedRef ) =>
                             'width' : referenceRef.current.clientWidth,
                             ...popperStyle,
                         } : popperStyle,
-                    ...rest,
+                    ref,
                 } );
             } }
         </Popper>
@@ -126,8 +126,8 @@ const PopperWrapper = forwardRef( ( props, forwardedRef ) =>
                         forwardedRef.current = ref;
                     }
                 } }>
-                { refProps => typeof children === 'function' &&
-                  children( { ...refProps, style } )
+                { ( { ref } ) => typeof children === 'function' &&
+                  children( { ref, style } )
                 }
             </Reference>
             { isVisible && popup }

--- a/src/PopperWrapper/index.jsx
+++ b/src/PopperWrapper/index.jsx
@@ -84,7 +84,7 @@ const PopperWrapper = forwardRef( ( props, forwardedRef ) =>
         }
     }, [ onClickOutside ] );
 
-    let popup = (
+    let popup = popper && (
         <Popper
             key       = { offset }
             placement = { popperPosition }
@@ -97,22 +97,20 @@ const PopperWrapper = forwardRef( ( props, forwardedRef ) =>
                     offset : `0, ${offset}`,
                 },
             } : offset }>
-            { ( { ref, style : popperStyle, scheduleUpdate } ) =>
+            { ( { style : popperStyle, scheduleUpdate, ...rest } ) =>
             {
                 scheduleUpdateRef.current = scheduleUpdate;
-
-                return (
-                    <div
-                        ref   = { ref }
-                        style = { matchRefWidth ? {
-                            'width' : referenceRef.current
-                                .clientWidth,
+                return popper( {
+                    style : matchRefWidth ?
+                        {
+                            'width' : referenceRef.current.clientWidth,
                             ...popperStyle,
-                        } : style }>
-                        { popper }
-                    </div> );
+                        } : popperStyle,
+                    ...rest,
+                } );
             } }
-        </Popper> );
+        </Popper>
+    );
 
     popup = containerEl ? ReactDOM.createPortal( popup, containerEl ) : popup;
 
@@ -127,11 +125,9 @@ const PopperWrapper = forwardRef( ( props, forwardedRef ) =>
                         forwardedRef.current = ref;
                     }
                 } }>
-                { ( { ref } ) => (
-                    <div ref = { ref } style = { style }>
-                        { children }
-                    </div>
-                ) }
+                { refProps => typeof children === 'function' &&
+                  children( { ...refProps, style } )
+                }
             </Reference>
             { isVisible && popup }
         </Manager>
@@ -141,9 +137,9 @@ const PopperWrapper = forwardRef( ( props, forwardedRef ) =>
 PopperWrapper.propTypes =
 {
     /**
-     *  Reference node to attach popper
+     *  Reference node render function
      */
-    children       : PropTypes.node,
+    children       : PropTypes.func,
     /**
      *  id of the DOM element used as container
      */
@@ -161,9 +157,9 @@ PopperWrapper.propTypes =
      */
     onClickOutside : PropTypes.func,
     /**
-     *  Popper content node
+     *  Popper content render function
      */
-    popper         : PropTypes.node,
+    popper         : PropTypes.func,
     /**
      *  Popper offset
      */

--- a/src/PopperWrapper/index.jsx
+++ b/src/PopperWrapper/index.jsx
@@ -122,6 +122,7 @@ const PopperWrapper = forwardRef( ( props, forwardedRef ) =>
                     referenceRef.current = ref;
                     if ( forwardedRef )
                     {
+                        // eslint-disable-next-line no-param-reassign
                         forwardedRef.current = ref;
                     }
                 } }>

--- a/src/PopperWrapper/index.jsx
+++ b/src/PopperWrapper/index.jsx
@@ -15,12 +15,14 @@ import React, {
     isValidElement,
     useCallback,
     useEffect,
-    useMemo,
     useRef,
-}                                         from 'react';
-import ReactDOM                           from 'react-dom';
-import { Manager, Reference, Popper }     from 'react-popper';
-import PropTypes                          from 'prop-types';
+}                                     from 'react';
+import ReactDOM                       from 'react-dom';
+import { Manager, Reference, Popper } from 'react-popper';
+import PropTypes                      from 'prop-types';
+
+import { useThemeVars }               from '../utils';
+
 
 const componentName = 'PopperWrapper';
 
@@ -41,18 +43,9 @@ const PopperWrapper = forwardRef( ( props, forwardedRef ) =>
     const referenceRef = useRef();
     const popperRef    = useRef();
 
-    const containerEl = useMemo( () => document.getElementById( container ),
-        [ container ] );
+    const { spacing } = useThemeVars();
+    const offset = spacing[ popperOffset ];
 
-    const offset = useMemo( () => (
-        {
-            'S'    : '8px',
-            'M'    : '16px',
-            'L'    : '24px',
-            'XL'   : '32px',
-            'none' : undefined,
-        }[ popperOffset ]
-    ), [ popperOffset ] );
 
     useEffect( () =>
     {
@@ -127,6 +120,7 @@ const PopperWrapper = forwardRef( ( props, forwardedRef ) =>
         </Popper>
     );
 
+    const containerEl = document.getElementById( container );
     popup = containerEl ? ReactDOM.createPortal( popup, containerEl ) : popup;
 
     return (
@@ -151,9 +145,9 @@ const PopperWrapper = forwardRef( ( props, forwardedRef ) =>
 PopperWrapper.propTypes =
 {
     /**
-     *  Reference node render function
+     *  Reference node (render function or element)
      */
-    children       : PropTypes.func,
+    children       : PropTypes.oneOfType( PropTypes.func, PropTypes.element ),
     /**
      *  id of the DOM element used as container
      */
@@ -171,13 +165,13 @@ PopperWrapper.propTypes =
      */
     onClickOutside : PropTypes.func,
     /**
-     *  Popper content render function
+     *  Popper node (render function or element)
      */
-    popper         : PropTypes.func,
+    popper         : PropTypes.oneOfType( PropTypes.func, PropTypes.element ),
     /**
      *  Popper offset
      */
-    popperOffset   : PropTypes.oneOf( [ 'S', 'M', 'L', 'XL', 'none' ] ),
+    popperOffset   : PropTypes.oneOf( [ 's', 'm', 'l', 'xl', 'none' ] ),
     /**
      *  Popper position
      */

--- a/src/PopperWrapper/index.jsx
+++ b/src/PopperWrapper/index.jsx
@@ -10,6 +10,7 @@
 /* global document, addEventListener, removeEventListener */
 
 import React, {
+    forwardRef,
     useCallback,
     useEffect,
     useMemo,
@@ -21,7 +22,7 @@ import PropTypes                          from 'prop-types';
 
 const componentName = 'PopperWrapper';
 
-const PopperWrapper = ( props ) =>
+const PopperWrapper = forwardRef( ( props, forwardedRef ) =>
 {
     const {
         children,
@@ -87,13 +88,16 @@ const PopperWrapper = ( props ) =>
         <Popper
             key       = { offset }
             placement = { popperPosition }
-            innerRef  = { ( ref ) => popperRef.current = ref }
+            innerRef  = { ref =>
+            {
+                popperRef.current = ref;
+            } }
             modifiers = { offset ? {
                 offset : {
                     offset : `0, ${offset}`,
                 },
             } : offset }>
-            { ( { ref, style, scheduleUpdate } ) =>
+            { ( { ref, style : popperStyle, scheduleUpdate } ) =>
             {
                 scheduleUpdateRef.current = scheduleUpdate;
 
@@ -103,7 +107,7 @@ const PopperWrapper = ( props ) =>
                         style = { matchRefWidth ? {
                             'width' : referenceRef.current
                                 .clientWidth,
-                            ...style,
+                            ...popperStyle,
                         } : style }>
                         { popper }
                     </div> );
@@ -115,7 +119,14 @@ const PopperWrapper = ( props ) =>
     return (
         <Manager>
             <Reference
-                innerRef  = { ( ref ) => referenceRef.current = ref }>
+                innerRef = { ref =>
+                {
+                    referenceRef.current = ref;
+                    if ( forwardedRef )
+                    {
+                        forwardedRef.current = ref;
+                    }
+                } }>
                 { ( { ref } ) => (
                     <div ref = { ref } style = { style }>
                         { children }
@@ -125,7 +136,7 @@ const PopperWrapper = ( props ) =>
             { isVisible && popup }
         </Manager>
     );
-};
+} );
 
 PopperWrapper.propTypes =
 {

--- a/src/Popup/index.jsx
+++ b/src/Popup/index.jsx
@@ -7,7 +7,7 @@
  *
  */
 
-import React                             from 'react';
+import React, { forwardRef }             from 'react';
 import PropTypes                         from 'prop-types';
 
 import { attachEvents, useThemeClasses } from '../utils';
@@ -15,7 +15,7 @@ import { attachEvents, useThemeClasses } from '../utils';
 
 const componentName = 'Popup';
 
-const Popup = props =>
+const Popup = forwardRef( ( props, ref ) =>
 {
     const { children, style } = props;
 
@@ -25,11 +25,12 @@ const Popup = props =>
         <div
             { ...attachEvents( props ) }
             className = { cssMap.main }
-            style = { style }>
+            ref       = { ref }
+            style     = { style }>
             { children }
         </div>
     );
-};
+} );
 
 Popup.propTypes = {
     children  : PropTypes.node,

--- a/src/Popup/index.jsx
+++ b/src/Popup/index.jsx
@@ -38,7 +38,6 @@ Popup.propTypes = {
     cssMap    : PropTypes.objectOf( PropTypes.string ),
     hasError  : PropTypes.bool,
     padding   : PropTypes.oneOf( [ 'none', 'S', 'M', 'L' ] ),
-    size      : PropTypes.oneOf( [ 'content', 'default' ] ),
     /**
      *  Style overrides
      */
@@ -51,8 +50,8 @@ Popup.defaultProps = {
     cssMap    : undefined,
     hasError  : false,
     padding   : 'none',
-    size      : 'default',
-    style     : undefined,
+
+    style : undefined,
 };
 
 Popup.displayName = componentName;

--- a/src/Popup/popup.css
+++ b/src/Popup/popup.css
@@ -11,6 +11,7 @@
 
 .default
 {
+    width:      unset;
     min-width:  0;
     max-width:  none;
 
@@ -39,14 +40,4 @@
 .padding__L
 {
     padding:    30px;
-}
-
-.size__default
-{
-    width: 100%;
-}
-
-.size__content
-{
-    width: auto;
 }

--- a/src/ProgressBar/index.jsx
+++ b/src/ProgressBar/index.jsx
@@ -7,15 +7,15 @@
  *
  */
 
-import React               from 'react';
-import PropTypes           from 'prop-types';
+import React, { forwardRef } from 'react';
+import PropTypes             from 'prop-types';
 
-import { useThemeClasses } from '../utils';
+import { useThemeClasses }   from '../utils';
 
 
 const componentName = 'ProgressBar';
 
-const ProgressBar = ( props ) =>
+const ProgressBar = forwardRef( ( props, ref ) =>
 {
     const { percentage, style } = props;
 
@@ -30,7 +30,7 @@ const ProgressBar = ( props ) =>
             }
         </div>
     );
-};
+} );
 
 ProgressBar.propTypes =
 {

--- a/src/Radio/index.jsx
+++ b/src/Radio/index.jsx
@@ -8,14 +8,10 @@
  */
 
 
-import React, {
-    useImperativeHandle,
-    useRef,
-    forwardRef,
-} from 'react';
-import PropTypes from 'prop-types';
+import React, { forwardRef } from 'react';
+import PropTypes             from 'prop-types';
 
-import { Text }  from '..';
+import { Text }              from '..';
 
 import {
     attachEvents,
@@ -28,12 +24,6 @@ const componentName = 'Radio';
 
 const Radio = forwardRef( ( props, ref ) =>
 {
-    const radioRef = useRef();
-
-    useImperativeHandle( ref, () => ( {
-        focus : () => radioRef.current.focus(),
-    } ) );
-
     const {
         children,
         isChecked,
@@ -56,7 +46,7 @@ const Radio = forwardRef( ( props, ref ) =>
     }
 
     return (
-        <div className = { cssMap.main } style = { style }>
+        <div className = { cssMap.main } ref = { ref } style = { style }>
             <input
                 { ...attachEvents( props ) }
                 checked   = { isChecked }

--- a/src/ScrollBar/index.jsx
+++ b/src/ScrollBar/index.jsx
@@ -14,7 +14,7 @@
 /* eslint-disable jsx-a11y/no-static-element-interactions */
 
 
-import React, { useCallback }                   from 'react';
+import React, { forwardRef, useCallback }       from 'react';
 import PropTypes                                from 'prop-types';
 
 import { attachEvents, clamp, useThemeClasses } from '../utils';
@@ -22,7 +22,7 @@ import { attachEvents, clamp, useThemeClasses } from '../utils';
 
 const componentName = 'ScrollBar';
 
-const ScrollBar = props =>
+const ScrollBar = forwardRef( ( props, forwardedRef ) =>
 {
     const {
         onChange,
@@ -32,8 +32,8 @@ const ScrollBar = props =>
         scrollMax,
         scrollMin,
         scrollPos,
-        thumbSize,
         style,
+        thumbSize,
     } = props;
 
     const cssMap = useThemeClasses( componentName, props );
@@ -102,7 +102,14 @@ const ScrollBar = props =>
             removeEventListener( 'mousemove', handleMouseMove );
             removeEventListener( 'mouseup', handleMouseUp );
         } );
-    }, [ isVertical, onChange, scrollLength, scrollMax, scrollMin, scrollPos ] );
+    }, [
+        isVertical,
+        onChange,
+        scrollLength,
+        scrollMax,
+        scrollMin,
+        scrollPos,
+    ] );
 
     return (
         <div
@@ -114,20 +121,27 @@ const ScrollBar = props =>
             aria-valuenow    = { scrollPos }
             className        = { cssMap.main }
             onClick          = { handleClick }
-            ref  = { trackRef }
-            role = "scrollbar"
-            style = { style }>
+            ref              = { ref =>
+            {
+                trackRef.current = ref;
+                if ( forwardedRef )
+                {
+                    forwardedRef.current = ref;
+                }
+            } }
+            role             = "scrollbar"
+            style            = { style }>
             <div
                 className   = { cssMap.thumb }
                 onMouseDown = { handleMouseDown }
-                ref   = { thumbRef }
-                style = { {
+                ref         = { thumbRef }
+                style       = { {
                     [ isVertical ? 'height' : 'width' ] : thumbSize,
                     [ isVertical ? 'top'    : 'left'  ] : thumbOffset,
                 } } />
         </div>
     );
-};
+} );
 
 ScrollBar.propTypes =
 {

--- a/src/ScrollBox/index.jsx
+++ b/src/ScrollBox/index.jsx
@@ -8,6 +8,7 @@
  */
 
 import React, {
+    forwardRef,
     useCallback,
     useEffect,
     useRef,
@@ -21,7 +22,7 @@ import { useThemeClasses }              from '../utils';
 
 const componentName = 'ScrollBox';
 
-const ScrollBox = props =>
+const ScrollBox = forwardRef( ( props, ref ) =>
 {
     const [ dimensions, setDimensions ] = useState( {
         clientHeight : null,
@@ -41,7 +42,9 @@ const ScrollBox = props =>
         const newDimensions = {};
 
         Object.keys( dimensions ).forEach( key =>
-            newDimensions[ key ] = innerRef.current[ key ] );
+        {
+            newDimensions[ key ] = innerRef.current[ key ];
+        } );
 
         if ( !isEqual( dimensions, newDimensions ) )
         {
@@ -106,7 +109,14 @@ const ScrollBox = props =>
             const increment = dir === 'Right' ? amount : -amount;
             innerRef.current.scrollLeft = dimensions.scrollLeft + increment;
         }
-    }, [ props, dimensions.clientHeight, dimensions.scrollTop, dimensions.clientWidth, dimensions.scrollLeft, scrollAmount ] );
+    }, [
+        dimensions.clientHeight,
+        dimensions.clientWidth,
+        dimensions.scrollLeft,
+        dimensions.scrollTop,
+        props,
+        scrollAmount,
+    ] );
 
     const handleClickTrackX = useCallback( ( pos ) =>
     {
@@ -292,6 +302,7 @@ const ScrollBox = props =>
             className    = { cssMap.main }
             onMouseEnter = { onMouseOver }
             onMouseLeave = { onMouseOut }
+            ref          = { ref }
             style        = { { maxHeight: height, ...style } }>
             <div
                 className = { cssMap.inner }
@@ -308,7 +319,7 @@ const ScrollBox = props =>
             { scrollBarsAreVisible && scrollBars }
         </div>
     );
-};
+} );
 
 ScrollBox.propTypes =
 {

--- a/src/Spinner/index.jsx
+++ b/src/Spinner/index.jsx
@@ -7,17 +7,17 @@
  *
  */
 
-import React               from 'react';
-import PropTypes           from 'prop-types';
+import React, { forwardRef } from 'react';
+import PropTypes             from 'prop-types';
 
-import { useThemeClasses } from '../utils';
+import { useThemeClasses }   from '../utils';
 
-import { Icon }            from '..';
+import { Icon }              from '..';
 
 
 const componentName = 'Spinner';
 
-const Spinner = ( props ) =>
+const Spinner = forwardRef( ( props, ref ) =>
 {
     const { size, style } = props;
 
@@ -26,12 +26,13 @@ const Spinner = ( props ) =>
     return (
         <Icon
             className = { cssMap.main }
-            type = "loader"
-            size = { size }
-            style = { style }
+            ref       = { ref }
+            size      = { size }
+            style     = { style }
+            type      = "loader"
         />
     );
-};
+} );
 
 Spinner.propTypes =
 {

--- a/src/Switch/index.jsx
+++ b/src/Switch/index.jsx
@@ -7,8 +7,8 @@
  *
  */
 
-import React        from 'react';
-import PropTypes    from 'prop-types';
+import React, { forwardRef } from 'react';
+import PropTypes             from 'prop-types';
 
 import {
     attachEvents,
@@ -19,7 +19,7 @@ import {
 
 const componentName = 'Switch';
 
-const Switch = props =>
+const Switch = forwardRef( ( props, ref ) =>
 {
     const {
         isChecked,
@@ -36,13 +36,14 @@ const Switch = props =>
         <div
             { ...attachEvents( props ) }
             className = { cssMap.main }
+            ref       = { ref }
             style     = { style }>
             <input
                 checked        = { isChecked }
                 className      = { cssMap.input }
+                defaultChecked = { isDefaultChecked }
                 disabled       = { isDisabled }
                 id             = { id }
-                defaultChecked = { isDefaultChecked }
                 type           = "checkbox" />
             <label
                 aria-label = { label }
@@ -50,7 +51,7 @@ const Switch = props =>
                 htmlFor    = { id } />
         </div>
     );
-};
+} );
 
 Switch.propTypes =
 {

--- a/src/Tab/index.jsx
+++ b/src/Tab/index.jsx
@@ -7,15 +7,15 @@
  *
  */
 
-import React                   from 'react';
-import PropTypes               from 'prop-types';
+import React, { forwardRef } from 'react';
+import PropTypes             from 'prop-types';
 
-import { useThemeClasses }     from '../utils';
+import { useThemeClasses }   from '../utils';
 
 
 const componentName = 'Tab';
 
-const Tab = ( props ) =>
+const Tab = forwardRef( ( props, ref ) =>
 {
     const cssMap = useThemeClasses( componentName, props );
     const {
@@ -26,14 +26,15 @@ const Tab = ( props ) =>
 
     return (
         <div
-            className  = { cssMap.main }
             aria-label = { label }
+            className  = { cssMap.main }
+            ref        = { ref }
             role       = "tabpanel"
             style      = { style }>
             { children }
         </div>
     );
-};
+} );
 
 Tab.propTypes =
 {

--- a/src/TabButton/index.jsx
+++ b/src/TabButton/index.jsx
@@ -8,9 +8,9 @@
  */
 
 import React, {
+    forwardRef,
     useImperativeHandle,
     useRef,
-    forwardRef,
 } from 'react';
 import PropTypes                         from 'prop-types';
 
@@ -21,23 +21,14 @@ const componentName = 'TabButton';
 
 const TabButton = forwardRef( ( props, ref ) =>
 {
-    const tabButtonRef = useRef();
-
-    useImperativeHandle( ref, () => ( {
-        focus : () =>
-        {
-            tabButtonRef.current.focus();
-        },
-    } ) );
-
     const cssMap = useThemeClasses( componentName, props );
 
     const {
         isDisabled,
         label,
+        style,
         subtitle,
         tabIndex,
-        style,
     } = props;
 
     return (
@@ -47,7 +38,7 @@ const TabButton = forwardRef( ( props, ref ) =>
             } ) }
             className = { cssMap.main }
             disabled  = { isDisabled }
-            ref       = { tabButtonRef }
+            ref       = { ref }
             role      = "tab"
             style     = { style }
             type      = "button">

--- a/src/Tabs/index.jsx
+++ b/src/Tabs/index.jsx
@@ -7,17 +7,17 @@
  *
  */
 
-import React, { useState, useCallback }        from 'react';
-import PropTypes                               from 'prop-types';
+import React, { forwardRef, useState, useCallback } from 'react';
+import PropTypes                                    from 'prop-types';
 
-import { ScrollBox, TabButton }                from '..';
+import { ScrollBox, TabButton }                     from '..';
 
-import { attachEvents, useThemeClasses }       from '../utils';
+import { attachEvents, useThemeClasses }            from '../utils';
 
 
 const componentName = 'Tabs';
 
-const Tabs = ( props ) =>
+const Tabs = forwardRef( ( props, ref ) =>
 {
     const cssMap = useThemeClasses( componentName, props );
 
@@ -84,7 +84,8 @@ const Tabs = ( props ) =>
         <div
             { ...attachEvents( props ) }
             className = { cssMap.main }
-            style = { style }>
+            ref       = { ref }
+            style     = { style }>
             <div className = { cssMap.header }>
                 <ScrollBox
                     className = { cssMap.tabsContainer }
@@ -104,7 +105,7 @@ const Tabs = ( props ) =>
             </div>
         </div>
     );
-};
+} );
 
 Tabs.propTypes =
 {

--- a/src/Tag/index.jsx
+++ b/src/Tag/index.jsx
@@ -7,17 +7,17 @@
  *
  */
 
-import React                       from 'react';
-import PropTypes                   from 'prop-types';
+import React, { forwardRef }      from 'react';
+import PropTypes                  from 'prop-types';
 
-import { IconButton, Text }        from '..';
+import { IconButton, Text }       from '..';
 
-import { useId, useThemeClasses }  from '../utils';
+import { useId, useThemeClasses } from '../utils';
 
 
 const componentName = 'Tag';
 
-const Tag = props =>
+const Tag = forwardRef( ( props, ref ) =>
 {
     const {
         children,
@@ -43,7 +43,7 @@ const Tag = props =>
     }
 
     return (
-        <div className = { cssMap.main } style = { style }>
+        <div className = { cssMap.main } ref = { ref } style = { style }>
             { labelText }
             <IconButton
                 className  = { cssMap.delete }
@@ -56,7 +56,7 @@ const Tag = props =>
                 } />
         </div>
     );
-};
+} );
 
 Tag.propTypes =
 {

--- a/src/TagInput/index.jsx
+++ b/src/TagInput/index.jsx
@@ -305,54 +305,52 @@ const TagInput = forwardRef( ( props, ref ) =>
         } )
     ) );
 
-    const popperChildren = (
-        <label
-            { ...attachEvents( props ) }
-            className = { cssMap.main }
-            htmlFor   = { id }
-            ref       = { ref }
-            style     = { style }>
-            { items }
-            <input
-                className   = { cssMap.input }
-                disabled    = { isDisabled }
-                id          = { id }
-                onBlur      = { callMultiple(
-                    handleBlur,
-                    props.onBlur,
-                ) } // temporary fix
-                onChange    = { handleChangeInput }
-                onFocus     = { callMultiple(
-                    handleFocus,
-                    props.onFocus,
-                ) } // temporary fix
-                onKeyDown   = { callMultiple(
-                    handleKeyDown,
-                    props.onKeyDown,
-                ) } // temporary fix
-                placeholder = { placeholder }
-                readOnly    = { isReadOnly }
-                type        = "text"
-                value       = { inputValue } />
-        </label>
-    );
-
-    const popperPopup = (
-        <Popup
-            hasError = { hasError }>
-            { dropdownContent }
-        </Popup>
-    );
-
     return (
         <PopperWrapper
             popperContainer = { popperContainer }
             isVisible       = { listBoxOptions.length > 0 && isOpen }
             matchRefWidth
-            popper          = { popperPopup }
+            popper          = { popperProps => (
+                <Popup
+                    hasError = { hasError }
+                    { ...popperProps }>
+                    { dropdownContent }
+                </Popup>
+            ) }
             popperOffset    = "S"
-            popperPosition  = "bottom">
-            { popperChildren }
+            popperPosition  = "bottom"
+            ref             = { ref }>
+            {  refProps => (
+                <label
+                    { ...attachEvents( props ) }
+                    className = { cssMap.main }
+                    htmlFor   = { id }
+                    style     = { style }
+                    { ...refProps }>
+                    { items }
+                    <input
+                        className   = { cssMap.input }
+                        disabled    = { isDisabled }
+                        id          = { id }
+                        onBlur      = { callMultiple(
+                            handleBlur,
+                            props.onBlur,
+                        ) } // temporary fix
+                        onChange    = { handleChangeInput }
+                        onFocus     = { callMultiple(
+                            handleFocus,
+                            props.onFocus,
+                        ) } // temporary fix
+                        onKeyDown   = { callMultiple(
+                            handleKeyDown,
+                            props.onKeyDown,
+                        ) } // temporary fix
+                        placeholder = { placeholder }
+                        readOnly    = { isReadOnly }
+                        type        = "text"
+                        value       = { inputValue } />
+                </label>
+            ) }
         </PopperWrapper>
     );
 } );

--- a/src/TagInput/index.jsx
+++ b/src/TagInput/index.jsx
@@ -9,11 +9,9 @@
 
 import React, {
     Children,
-    useState,
-    useRef,
-    useMemo,
-    useImperativeHandle,
     forwardRef,
+    useMemo,
+    useState,
 } from 'react';
 import PropTypes           from 'prop-types';
 import { escapeRegExp }    from 'lodash';
@@ -81,9 +79,6 @@ const componentName = 'TagInput';
 
 const TagInput = forwardRef( ( props, ref ) =>
 {
-    const inputRef = useRef();
-    const outerRef = useRef();
-
     const cssMap = useThemeClasses( componentName, props );
     const id = useId( componentName, props );
 
@@ -120,13 +115,6 @@ const TagInput = forwardRef( ( props, ref ) =>
     const value = useMemo( () => (
         ( Array.isArray( props.value ) && props.value ) || valueState
     ), [ props.value, valueState ] );
-
-    useImperativeHandle( ref, () => ( {
-        focus : () =>
-        {
-            inputRef.current.focus();
-        },
-    } ) );
 
     const enterNewTag = () =>
     {
@@ -322,7 +310,7 @@ const TagInput = forwardRef( ( props, ref ) =>
             { ...attachEvents( props ) }
             className = { cssMap.main }
             htmlFor   = { id }
-            ref       = { outerRef }
+            ref       = { ref }
             style     = { style }>
             { items }
             <input
@@ -344,7 +332,6 @@ const TagInput = forwardRef( ( props, ref ) =>
                 ) } // temporary fix
                 placeholder = { placeholder }
                 readOnly    = { isReadOnly }
-                ref         = { inputRef }
                 type        = "text"
                 value       = { inputValue } />
         </label>

--- a/src/Text/index.jsx
+++ b/src/Text/index.jsx
@@ -7,7 +7,7 @@
  *
  */
 
-import React                             from 'react';
+import React, { forwardRef }             from 'react';
 import PropTypes                         from 'prop-types';
 
 import { attachEvents, useThemeClasses } from '../utils';
@@ -15,7 +15,7 @@ import { attachEvents, useThemeClasses } from '../utils';
 
 const componentName = 'Text';
 
-const Text = props =>
+const Text = forwardRef( ( props, ref ) =>
 {
     const {
         children,
@@ -24,7 +24,6 @@ const Text = props =>
         lineHeight,
         style,
         text,
-        textRef,
     } = props;
 
     const cssMap = useThemeClasses( componentName, props );
@@ -33,14 +32,14 @@ const Text = props =>
         <div
             { ...attachEvents( props ) }
             className = { cssMap.main }
-            ref       = { textRef }
+            ref       = { ref }
             style     = { {
                 color, letterSpacing, lineHeight, ...style,
             } }>
             { children || text }
         </div>
     );
-};
+} );
 
 Text.propTypes =
 {
@@ -112,10 +111,6 @@ Text.propTypes =
      */
     textAlign : PropTypes.oneOf( [ 'left', 'center', 'right' ] ),
     /**
-     *  Callback that receives ref to the text div: ref => ...
-     */
-    textRef   : PropTypes.func,
-    /**
      *  Style to apply to text
      */
     variant   : PropTypes.oneOf( [
@@ -152,7 +147,6 @@ Text.defaultProps =
     style            : undefined,
     text             : undefined,
     textAlign        : undefined,
-    textRef          : undefined,
     variant          : 'Regular',
 };
 

--- a/src/TextArea/index.jsx
+++ b/src/TextArea/index.jsx
@@ -7,10 +7,8 @@
  *
  */
 
-import React, {
-    useRef, useImperativeHandle, forwardRef,
-} from 'react';
-import PropTypes from 'prop-types';
+import React, { forwardRef } from 'react';
+import PropTypes             from 'prop-types';
 
 import {
     attachEvents,
@@ -24,12 +22,6 @@ const componentName = 'TextArea';
 const TextArea = forwardRef( ( props, ref ) =>
 {
     const cssMap = useThemeClasses( componentName, props );
-
-    const textAreaRef = useRef();
-
-    useImperativeHandle( ref, () => ( {
-        focus : () => textAreaRef.current.focus(),
-    } ) );
 
     const {
         aria,
@@ -60,7 +52,7 @@ const TextArea = forwardRef( ( props, ref ) =>
             id             = { id }
             placeholder    = { placeholder }
             readOnly       = { isReadOnly }
-            ref            = { textAreaRef }
+            ref            = { ref }
             rows           = { rows }
             spellCheck     = { spellCheck }
             style          = { style }

--- a/src/TextInput/index.jsx
+++ b/src/TextInput/index.jsx
@@ -7,12 +7,8 @@
  *
  */
 
-import React, {
-    useImperativeHandle,
-    useRef,
-    forwardRef,
-}                   from 'react';
-import PropTypes    from 'prop-types';
+import React, { forwardRef } from 'react';
+import PropTypes             from 'prop-types';
 
 import {
     attachEvents,
@@ -25,13 +21,7 @@ const componentName = 'TextInput';
 
 const TextInput = forwardRef( ( props, ref ) =>
 {
-    const inputRef = useRef();
     const cssMap = useThemeClasses( componentName, props );
-
-    useImperativeHandle( ref, () => ( {
-        focus : () => inputRef.current.focus(),
-    } ) );
-
     const {
         aria,
         autoCapitalize,
@@ -61,7 +51,7 @@ const TextInput = forwardRef( ( props, ref ) =>
             id             = { id }
             placeholder    = { placeholder }
             readOnly       = { isReadOnly }
-            ref            = { inputRef }
+            ref            = { ref }
             spellCheck     = { spellCheck }
             style          = { style }
             type           = { type }

--- a/src/TextInputWithIcon/index.jsx
+++ b/src/TextInputWithIcon/index.jsx
@@ -7,17 +7,17 @@
  *
  */
 
-import React                               from 'react';
-import PropTypes                           from 'prop-types';
+import React, { forwardRef }             from 'react';
+import PropTypes                         from 'prop-types';
 
-import { attachEvents, useThemeClasses }   from '../utils';
+import { attachEvents, useThemeClasses } from '../utils';
 
-import { IconButton, TextInput }           from '..';
+import { IconButton, TextInput }         from '..';
 
 
 const componentName = 'TextInputWithIcon';
 
-const TextInputWithIcon = ( props ) =>
+const TextInputWithIcon = forwardRef( ( props, ref ) =>
 {
     const cssMap = useThemeClasses( componentName, props );
 
@@ -32,7 +32,6 @@ const TextInputWithIcon = ( props ) =>
         iconPosition,
         iconType,
         id,
-        inputRef,
         inputType,
         isDisabled,
         isReadOnly,
@@ -75,7 +74,7 @@ const TextInputWithIcon = ( props ) =>
                 onChange       = { onChangeInput }
                 onKeyDown      = { onKeyDownInput }
                 placeholder    = { placeholder }
-                ref            = { inputRef }
+                ref            = { ref }
                 spellcheck     = { spellCheck }
                 textAlign      = { alignText }
                 type           = { inputType }
@@ -91,7 +90,7 @@ const TextInputWithIcon = ( props ) =>
             }
         </div>
     );
-};
+} );
 
 TextInputWithIcon.propTypes =
 {
@@ -154,10 +153,6 @@ TextInputWithIcon.propTypes =
      *  Component id
      */
     id                   : PropTypes.string,
-    /**
-     *  Callback that receives the native <input>: ( ref ) => { ... }
-     */
-    inputRef             : PropTypes.func,
     /**
      *  HTML input type
      */
@@ -242,7 +237,6 @@ TextInputWithIcon.defaultProps =
     iconPosition         : 'right',
     iconType             : 'none',
     id                   : undefined,
-    inputRef             : undefined,
     inputType            : 'text',
     isDisabled           : false,
     isReadOnly           : false,

--- a/src/defaults.json
+++ b/src/defaults.json
@@ -87,13 +87,9 @@
 		"children": "Popup content",
 		"padding": "M"
 	},
-	"PopperWrapper": {
-		"children": "{<Button label=\"Click me!\" />}",
-		"popper": "{<Popup padding=\"M\">Popup content</Popup>}"
-	},
-    "ProgressBar": {
-        "percentage": 20
-    },
+  "ProgressBar": {
+      "percentage": 20
+  },
 	"ScrollBar": {
 		"scrollMax": 100
 	},

--- a/src/defaults.json
+++ b/src/defaults.json
@@ -87,6 +87,10 @@
 		"children": "Popup content",
 		"padding": "M"
 	},
+	"PopperWrapper": {
+		"children": "{<Button label=\"Click me!\" />}",
+		"popper": "{<Popup padding=\"M\">Popup content</Popup>}"
+	},
   "ProgressBar": {
       "percentage": 20
   },


### PR DESCRIPTION
## What this does

This PR:
- Updates all components use `React.forwardRef` to passthru a ref to the outermost element of the component
- Consequently:
    - PopperWrapper no longer adds wrapper divs. Instead `children` and `popper` are now functions / render props
    - Removed instances of `useImperativeHandle `
    - Added a note in `README.md` about how to do focus management without an explicit ref to the input that you need to focus

## But why?!

In order to use [`react-pose`](https://github.com/Popmotion/popmotion/tree/master/packages/react-pose) to animate anything and everything to your heart’s content.